### PR TITLE
Fix mindcontrol cargo bug on rv-engine

### DIFF
--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -79,6 +79,9 @@ namespace OpenRA.Mods.Common.Traits
 			"A dictionary of [actor id]: [condition].")]
 		public readonly Dictionary<string, string> PassengerConditions = new Dictionary<string, string>();
 
+		[Desc("Change the passengers owner if transport owner changed")]
+		public readonly bool OwnerChangedAffectsPassengers = true;
+
 		[GrantedConditionReference]
 		public IEnumerable<string> LinterPassengerConditions { get { return PassengerConditions.Values; } }
 
@@ -462,7 +465,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
-			if (cargo == null)
+			if (!Info.OwnerChangedAffectsPassengers || cargo == null)
 				return;
 
 			foreach (var p in Passengers)


### PR DESCRIPTION
## About bug to fix
GIF to show the bug related cargo trait and mindcontrol warhead.
![bug](https://user-images.githubusercontent.com/13763394/95189443-702dbd00-0800-11eb-926f-d6262e81383a.gif)
As you can see mindcontrol weapon temporarily control the transport, but makes all the passengers permanently change owner. This will be horrible in gameplay, especially for huge transport carries tons of vehicles and infantry in RV.

## About fixing in this PR
Simply give an option (`OwnerChangedAffectsPassengers`) can let player turn off the owner change to passengers when transport's owner is changed. It set to true at default to compatible the place don't have to change for fixing mindcontrol weapon affected transport target.

After use this fix and add "OwnerChangedAffectsPassengers: false"
![fixed](https://user-images.githubusercontent.com/13763394/95190735-58efcf00-0802-11eb-9bdc-fa53033d18e0.gif)

## About should this goes to upstream
I think it is not possible PR this to upstream due to:
1. Upstream don't have usecase on temporarily owner change on transport unit
2. `Cargo` is planned to be refactor as they declared, so add this may be useless for future.