### PR TITLE
Avoid crash bug by NavyBuilding check

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -27,6 +27,10 @@ namespace OpenRA.Mods.Common.Traits
 		readonly PowerManager playerPower;
 		readonly PlayerResources playerResources;
 
+		// need this to avoid crash in WaterCheck when there is no NavalProductionTypes
+		// TODO: remove it when related crash is fixed.
+		readonly bool shouldWaterCheck;
+
 		int waitTicks;
 		Actor[] playerBuildings;
 		int failCount;
@@ -51,6 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 			failRetryTicks = baseBuilder.Info.StructureProductionResumeDelay;
 			minimumExcessPower = baseBuilder.Info.MinimumExcessPower;
 			this.resourceTypeIndices = resourceTypeIndices;
+			shouldWaterCheck = baseBuilder.Info.NavalProductionTypes.Any();
 		}
 
 		public void Tick(IBot bot)
@@ -70,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 					failRetryTicks = baseBuilder.Info.StructureProductionResumeDelay;
 			}
 
-			if (waterState == WaterCheck.NotChecked)
+			if (shouldWaterCheck && waterState == WaterCheck.NotChecked)
 			{
 				if (AIUtils.IsAreaAvailable<BaseProvider>(world, player, world.Map, baseBuilder.Info.MaxBaseRadius, baseBuilder.Info.WaterTerrainTypes))
 					waterState = WaterCheck.EnoughWater;
@@ -81,7 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 
-			if (waterState == WaterCheck.NotEnoughWater && --checkForBasesTicks <= 0)
+			if (shouldWaterCheck && waterState == WaterCheck.NotEnoughWater && --checkForBasesTicks <= 0)
 			{
 				var currentBases = world.ActorsHavingTrait<BaseProvider>().Count(a => a.Owner == player);
 


### PR DESCRIPTION
## About the bug
This is a **Crash Bug** happens in SP when AI players with map contains water: there is a chance that the `AIUtils.IsAreaAvailable` in water check will crash the game with access array with invalid index. 

Detailed information [here](https://github.com/ABrandau/Shattered-Paradise-SDK/issues/94).

## About the fix
I don't have the ability to fix `AIUtils` due to it is complex and cascade to many places. So I simply skip the water check if user don't have anything to build in water.

I found the bug 4 months ago when I am doing localization and bug fixes for SP, and I used this method fixing, or I have to say, avoiding this crash.

 After using this fix, the replay in [crash replay](https://github.com/ABrandau/Shattered-Paradise-SDK/issues/94) won't crash when at the place where crash happens.

## About should this go to upstream
Upstream will not accept it because water check should do this work, but it is better to inform them that they will have to check base builder module related and `AIUtils` carefully.

It is better to get this bug reproducable in default mods of OpenRA, which will be more conceivable. 