### PR TITLE
Air ai fix

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/PowerDownBotManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/PowerDownBotManager.cs
@@ -117,6 +117,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			var power = playerPower.ExcessPower;
+			List<Actor> togglingBuildings = new List<Actor>();
 
 			// When there is extra power, check if AI can toggle on
 			if (power > 0)
@@ -128,7 +129,7 @@ namespace OpenRA.Mods.Common.Traits
 					if (power + bpw.ExpectedPowerChanging < 0)
 						continue;
 
-					bot.QueueOrder(new Order(Info.OrderName, bpw.Actor, false));
+					togglingBuildings.Add(bpw.Actor);
 					power += bpw.ExpectedPowerChanging;
 					toggledBuildings.RemoveAt(i);
 				}
@@ -144,10 +145,15 @@ namespace OpenRA.Mods.Common.Traits
 					if (power > 0)
 						break;
 
-					bot.QueueOrder(new Order(Info.OrderName, bpw.Actor, false));
+					togglingBuildings.Add(bpw.Actor);
 					toggledBuildings.Add(new BuildingPowerWrapper(bpw.Actor, -bpw.ExpectedPowerChanging));
 					power += bpw.ExpectedPowerChanging;
 				}
+			}
+
+			if (togglingBuildings.Count > 0)
+			{
+				bot.QueueOrder(new Order(Info.OrderName, null, false, groupedActors: togglingBuildings.ToArray()));
 			}
 
 			toggleTick = Info.Interval;

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
@@ -172,9 +172,9 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 			var unitsAroundPos = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(owner.SquadManager.Info.DangerScanRadius))
 				.Where(a => owner.SquadManager.IsPreferredEnemyUnit(a) && owner.SquadManager.IsNotHiddenUnit(a));
-			var ambushed = CountAntiAirUnits(unitsAroundPos) > owner.Units.Count;
 
-			if (ambushed || !NearToPosSafely(owner, owner.TargetActor.CenterPosition))
+			// Check if get ambushed.
+			if (CountAntiAirUnits(unitsAroundPos) > owner.Units.Count)
 			{
 				owner.FuzzyStateMachine.ChangeState(owner, new AirFleeState(), false);
 				return;

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
@@ -211,8 +211,6 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 		public void Tick(Squad owner)
 		{
-			var cannotRetaliate = false;
-
 			// Basic check
 			if (!owner.IsValid)
 				return;
@@ -226,6 +224,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			var attackScanRadius = WDist.FromCells(owner.SquadManager.Info.AttackScanRadius);
 			var targetActor = owner.SquadManager.FindClosestEnemy(leader.CenterPosition, attackScanRadius);
 
+			var cannotRetaliate = true;
 			if (targetActor == null)
 			{
 				owner.FuzzyStateMachine.RevertToPreviousState(owner, true);
@@ -233,7 +232,6 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			}
 			else
 			{
-				cannotRetaliate = true;
 				owner.TargetActor = targetActor;
 
 				foreach (var a in owner.Units)

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
@@ -154,15 +154,13 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		// Retreat units from combat, or for supply only in idle
 		protected void Retreat(Squad squad, bool flee, bool rearm, bool repair)
 		{
-			var loc = new CPos(0, 0, 0);
-
 			// HACK: "alreadyRepair" is to solve AI repair orders performance,
 			// which is only allow one goes to repairpad at the same time to avoid queueing too many orders.
 			// if repairpad logic is better we can just drop it.
 			var alreadyRepair = false;
 
-			if (flee)
-				loc = RandomBuildingLocation(squad);
+			List<Actor> rearmingUnits = new List<Actor>();
+			List<Actor> fleeingUnits = new List<Actor>();
 
 			foreach (var a in squad.Units)
 			{
@@ -171,18 +169,19 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 				var orderQueued = false;
 
-				// Try rearm units.
+				// Units need to rearm will be added to rearming group.
 				if (rearm)
 				{
 					var ammoPools = a.TraitsImplementing<AmmoPool>().ToArray();
 					if (!ReloadsAutomatically(ammoPools, a.TraitOrDefault<Rearmable>()) && !FullAmmo(ammoPools))
 					{
-						squad.Bot.QueueOrder(new Order("ReturnToBase", a, orderQueued));
+						rearmingUnits.Add(a);
 						orderQueued = true;
 					}
 				}
 
 				// Try repair units.
+				// Don't use grounp order here becuase we have 2 kinds of repaid orders and we need to find repair building for both traits.
 				if (repair && !alreadyRepair)
 				{
 					Actor repairBuilding = null;
@@ -213,10 +212,16 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 					}
 				}
 
-				// If there is no order in queue and units should flee, try flee.
+				// If there is no order in queue and units should flee, add unit to fleeing group.
 				if (flee && !orderQueued)
-					squad.Bot.QueueOrder(new Order("Move", a, Target.FromCell(squad.World, loc), false));
+					fleeingUnits.Add(a);
 			}
+
+			if (rearmingUnits.Count > 0)
+				squad.Bot.QueueOrder(new Order("ReturnToBase", null, true, groupedActors: rearmingUnits.ToArray()));
+
+			if (fleeingUnits.Count > 0)
+				squad.Bot.QueueOrder(new Order("Move", null, Target.FromCell(squad.World, RandomBuildingLocation(squad)), false, groupedActors: fleeingUnits.ToArray()));
 		}
 	}
 }


### PR DESCRIPTION
1. Airstate(Attack) consider cannot attack condition
2. GroundState(Attack) small optimizing
3. Airstate(Attack): Drop danger scan for target position
- Danger scan aircraft surrounding each tick is enough for AI air squad to decide to retreat or not, which is the most directly effective way.
- It is pointless to scan if target is surrounding by anti-air each tick. if target is just passing by a group of anti-air which result in air squad retreat, the air squad will stall themselve and scan the map more while rechoosing the target, while scan the map is quite expensive.
4. Group order overhaul for AI logic.