### PR TITLE
Weapon related upgrade

### DIFF
--- a/AUTHORS.AS
+++ b/AUTHORS.AS
@@ -25,12 +25,20 @@ The plugin is maintained by
  * CastleJing
    > Bugfixes on mind controller logic
 
+ * CombinE88
+   > BackFireShrapnelWarhead
+
  * darkscrypt (Devon/wolfbyte)
    > Major rewrite on garrison code
    > Smart deploy logic
 
  * DnAp
    > Initial garrison logic
+
+ * Dnqbob
+   > AI squad logic fix
+   > Bugfixes on mind controller logic with cargo
+   > PowerDownBotModule
 
  * Holloweye
    > SmokeParticle(Emitter) basic implementation

--- a/OpenRA.Mods.AS/Duplicates/Projectiles/BulletAS.cs
+++ b/OpenRA.Mods.AS/Duplicates/Projectiles/BulletAS.cs
@@ -32,8 +32,8 @@ namespace OpenRA.Mods.AS.Projectiles
 		[Desc("Image to display.")]
 		public readonly string Image = null;
 
+		[SequenceReference(nameof(Image), allowNullImage: true)]
 		[Desc("Loop a randomly chosen sequence of Image from this list while this projectile is moving.")]
-		[SequenceReference("Image")]
 		public readonly string[] Sequences = { "idle" };
 
 		[Desc("The palette used to draw this projectile.")]
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.AS.Projectiles
 		public readonly string TrailImage = null;
 
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
-		[SequenceReference("TrailImage")]
+		[SequenceReference(nameof(TrailImage), allowNullImage: true)]
 		public readonly string[] TrailSequences = { "idle" };
 
 		[Desc("Is this blocked by actors with BlocksProjectiles trait.")]
@@ -68,6 +68,12 @@ namespace OpenRA.Mods.AS.Projectiles
 		[Desc("Up to how many times does this bullet bounce when touching ground without hitting a target.",
 			"0 implies exploding on contact with the originally targeted position.")]
 		public readonly int BounceCount = 0;
+
+		[Desc("Sound to play when the projectile hits the ground, but not the target.")]
+		public readonly string BounceSound = null;
+
+		[Desc("Terrain where the projectile explodes instead of bouncing.")]
+		public readonly HashSet<string> InvalidBounceTerrain = new HashSet<string>();
 
 		[Desc("Modify distance of each bounce by this percentage of previous distance.")]
 		public readonly int BounceRangeModifier = 60;
@@ -113,6 +119,7 @@ namespace OpenRA.Mods.AS.Projectiles
 		readonly BulletASInfo info;
 		readonly ProjectileArgs args;
 		readonly Animation anim;
+
 		[Sync]
 		readonly WAngle angle;
 		[Sync]
@@ -120,9 +127,10 @@ namespace OpenRA.Mods.AS.Projectiles
 		[Sync]
 		readonly WAngle facing;
 
+		readonly string trailPalette;
+		readonly string palette;
+
 		ContrailRenderable contrail;
-		string trailPalette;
-		string palette;
 
 		[Sync]
 		WPos pos, lastPos, target, source;
@@ -158,8 +166,8 @@ namespace OpenRA.Mods.AS.Projectiles
 			target = args.PassiveTarget;
 			if (info.Inaccuracy.Length > 0)
 			{
-				var inaccuracy = OpenRA.Mods.Common.Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
-				var range = OpenRA.Mods.Common.Util.ApplyPercentageModifiers(args.Weapon.Range.Length, args.RangeModifiers);
+				var inaccuracy = Common.Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
+				var range = Common.Util.ApplyPercentageModifiers(args.Weapon.Range.Length, args.RangeModifiers);
 				var maxOffset = inaccuracy * (target - pos).Length / range;
 				target += WVec.FromPDF(world.SharedRandom, 2) * maxOffset / 1024;
 			}
@@ -215,14 +223,17 @@ namespace OpenRA.Mods.AS.Projectiles
 			lastPos = pos;
 			pos = WPos.LerpQuadratic(source, target, angle, ticks, length);
 
-			// Check for walls or other blocking obstacles
-			var shouldExplode = false;
-			WPos blockedPos;
+			if (ShouldExplode(world))
+				Explode(world);
+		}
+
+		bool ShouldExplode(World world)
+		{
 			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, lastPos, pos, info.Width,
-				out blockedPos))
+				out var blockedPos))
 			{
 				pos = blockedPos;
-				shouldExplode = true;
+				return true;
 			}
 
 			if (!string.IsNullOrEmpty(info.TrailImage) && --smokeTicks < 0)
@@ -242,31 +253,43 @@ namespace OpenRA.Mods.AS.Projectiles
 
 			if (flightLengthReached && shouldBounce)
 			{
-				shouldExplode |= AnyValidTargetsInRadius(world, pos, info.Width, args.SourceActor, true);
+				var cell = world.Map.CellContaining(pos);
+				if (!world.Map.Contains(cell))
+					return true;
+
+				if (info.InvalidBounceTerrain.Contains(world.Map.GetTerrainInfo(cell).Type))
+					return true;
+
+				if (AnyValidTargetsInRadius(world, pos, info.Width, args.SourceActor, true))
+					return true;
+
 				target += (pos - source) * info.BounceRangeModifier / 100;
 				var dat = world.Map.DistanceAboveTerrain(target);
 				target += new WVec(0, 0, -dat.Length);
 				length = Math.Max((target - pos).Length / speed.Length, 1);
+
 				ticks = 0;
 				source = pos;
+				Game.Sound.Play(SoundType.World, info.BounceSound, source);
 				remainingBounces--;
 			}
 
 			// Flight length reached / exceeded
-			shouldExplode |= flightLengthReached && !shouldBounce;
+			if (flightLengthReached && !shouldBounce)
+				return true;
 
 			// Driving into cell with different height level
-			shouldExplode |= world.Map.DistanceAboveTerrain(pos) < info.ExplodeUnderThisAltitude;
+			if (world.Map.DistanceAboveTerrain(pos) < info.ExplodeUnderThisAltitude)
+				return true;
 
 			// After first bounce, check for targets each tick
-			if (remainingBounces < info.BounceCount)
-				shouldExplode |= AnyValidTargetsInRadius(world, pos, info.Width, args.SourceActor, true);
+			if (remainingBounces < info.BounceCount && AnyValidTargetsInRadius(world, pos, info.Width, args.SourceActor, true))
+				return true;
 
-			if (!string.IsNullOrEmpty(info.PointDefenseType))
-				shouldExplode |= world.ActorsWithTrait<IPointDefense>().Any(x => x.Trait.Destroy(pos, args.SourceActor.Owner, info.PointDefenseType));
+			if (!string.IsNullOrEmpty(info.PointDefenseType) && world.ActorsWithTrait<IPointDefense>().Any(x => x.Trait.Destroy(pos, args.SourceActor.Owner, info.PointDefenseType)))
+				return true;
 
-			if (shouldExplode)
-				Explode(world);
+			return false;
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
@@ -316,7 +339,7 @@ namespace OpenRA.Mods.AS.Projectiles
 				if (checkTargetType && !Target.FromActor(victim).IsValidFor(firedBy))
 					continue;
 
-				if (!info.ValidBounceBlockerStances.HasStance(victim.Owner.RelationshipWith(firedBy.Owner)))
+				if (!info.ValidBounceBlockerStances.HasStance(firedBy.Owner.RelationshipWith(victim.Owner)))
 					continue;
 
 				// If the impact position is within any actor's HitShape, we have a direct hit

--- a/OpenRA.Mods.AS/Warheads/BackFireShrapnelWarhead.cs
+++ b/OpenRA.Mods.AS/Warheads/BackFireShrapnelWarhead.cs
@@ -1,0 +1,87 @@
+#region Copyright & License Information
+/*
+ * Copyright 2015- OpenRA.Mods.AS Developers (see AUTHORS)
+ * This file is a part of a third-party plugin for OpenRA, which is
+ * free software. It is made available to you under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation. For more information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.GameRules;
+using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.AS.Warheads
+{
+	[Desc("A creative warhead in MW, made by CombinE88")]
+	public class BackFireShrapnelWarhead : WarheadAS, IRulesetLoaded<WeaponInfo>
+	{
+		[WeaponReference]
+		[FieldLoader.Require]
+		[Desc("Has to be defined in weapons.yaml as well.")]
+		public readonly string Weapon = null;
+
+		WeaponInfo weapon;
+
+		public void RulesetLoaded(Ruleset rules, WeaponInfo info)
+		{
+			if (!rules.Weapons.TryGetValue(Weapon.ToLowerInvariant(), out weapon))
+			throw new YamlException("Weapons Ruleset does not contain an entry '{0}'".F(Weapon.ToLowerInvariant()));
+		}
+
+		public override void DoImpact(in Target target, WarheadArgs args)
+		{
+			Actor firedBy = args.SourceActor;
+
+			if (!IsValidImpact(target.CenterPosition, firedBy))
+				return;
+
+			Target shrapnelTarget = Target.Invalid;
+
+			shrapnelTarget = Target.FromActor(firedBy);
+
+			if (shrapnelTarget.Type != TargetType.Invalid)
+			{
+				var pargs = new ProjectileArgs
+				{
+					Weapon = weapon,
+					Facing = (shrapnelTarget.CenterPosition - target.CenterPosition).Yaw,
+
+					DamageModifiers = !firedBy.IsDead
+						? firedBy.TraitsImplementing<IFirepowerModifier>()
+							.Select(a => a.GetFirepowerModifier()).ToArray()
+						: new int[0],
+
+					InaccuracyModifiers = !firedBy.IsDead
+						? firedBy.TraitsImplementing<IInaccuracyModifier>()
+							.Select(a => a.GetInaccuracyModifier()).ToArray()
+						: new int[0],
+
+					RangeModifiers = !firedBy.IsDead
+						? firedBy.TraitsImplementing<IRangeModifier>()
+							.Select(a => a.GetRangeModifier()).ToArray()
+						: new int[0],
+
+					Source = target.CenterPosition,
+					SourceActor = firedBy,
+					GuidedTarget = shrapnelTarget,
+					PassiveTarget = shrapnelTarget.CenterPosition
+				};
+
+				if (pargs.Weapon.Projectile != null)
+				{
+				var projectile = pargs.Weapon.Projectile.Create(pargs);
+				if (projectile != null)
+						firedBy.World.AddFrameEndTask(w => w.Add(projectile));
+
+				if (pargs.Weapon.Report != null && pargs.Weapon.Report.Any())
+						Game.Sound.Play(SoundType.World, pargs.Weapon.Report.Random(firedBy.World.SharedRandom), target.CenterPosition);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
1. Update BulletAS. The old version is not working well on bounce. 
2. Introduce BackFireShrapnelWarhead from MW (under GPL3.0). Changed to catch up with current OpenRA
2.1 we can use this warhead to do leeching weapon like vampire in MW,  backfire heal itself. 
2.2 we can also make boomerang weapon both visually and functionally (only when hit by back fire boomerang, ammo pool is reloaded) 
2.3 we can make effect that actor attack with part of its body, which will fly back. 
