### PR TITLE
AI choosing building variant for BaseBuilderQueueManager

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/PlaceBuildingVariants.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PlaceBuildingVariants.cs
@@ -21,6 +21,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Variant actors that can be cycled between when placing a structure.")]
 		public readonly string[] Actors = null;
 
+		[Desc("Facings reference of variant actors. Should always have the length of number of Variant Actors + 1, due to the first element refer to actor itself")]
+		public readonly WAngle[] Facings = null;
+
 		public override object Create(ActorInitializer init) { return new PlaceBuildingVariants(); }
 	}
 


### PR DESCRIPTION
Usage: 
1. Add Facing to refinery with facings like:
```
	PlaceBuildingVariants:
		Actors: refinery-nw, refinery-ne, refinery-se
		Facings: 640, 896, 128, 384 ## 640 is the actor itself facing
```

2. In AI.yaml, add All related building variants to those lines below:
```
		RefineryTypes: refinery, refinery-nw, refinery-ne, refinery-se
		PowerTypes: pwrplt, advpwr, pwrplt-3x2
		BarracksTypes: barracks, nhand, nhand-2x3
		VehiclesFactoryTypes: warfactory, airstrip
		ProductionTypes: barracks, nhand, warfactory, airstrip, helipad, nhand-2x3
```

The AI will 
1. build refinery towards minefield. ~~(Not always correct, though)~~ Fixed now
2. build a random building variant actor if building has variant actor.
![QQ图片20220220212022](https://user-images.githubusercontent.com/13763394/154844656-6120cca4-ed19-47f8-85d9-2f8ec896a4ed.jpg)
![QQ图片20220220212022](https://user-images.githubusercontent.com/13763394/154844729-ff6c2223-91f0-4acd-9170-3faf5d13512c.jpg)

