### PR TITLE
Add advance contrail used by TA

### DIFF
--- a/OpenRA.Mods.AS/Duplicates/Projectiles/BulletAS.cs
+++ b/OpenRA.Mods.AS/Duplicates/Projectiles/BulletAS.cs
@@ -107,9 +107,13 @@ namespace OpenRA.Mods.AS.Projectiles
 		public readonly int ContrailLength = 0;
 		public readonly int ContrailZOffset = 2047;
 		public readonly Color ContrailColor = Color.White;
+		public readonly Color ContrailEndColor = Color.White;
 		public readonly bool ContrailUsePlayerColor = false;
-		public readonly int ContrailDelay = 1;
+		public readonly int ContrailDelay = 0;
 		public readonly WDist ContrailWidth = new WDist(64);
+		public readonly bool ContrailFadeWithColor = true;
+		public readonly bool ContrailFadeWithWidth = false;
+		public readonly float ContrailFadeWithWidthRate = 1f;
 
 		public IProjectile Create(ProjectileArgs args) { return new BulletAS(this, args); }
 	}
@@ -189,7 +193,8 @@ namespace OpenRA.Mods.AS.Projectiles
 			if (info.ContrailLength > 0)
 			{
 				var color = info.ContrailUsePlayerColor ? ContrailRenderable.ChooseColor(args.SourceActor) : info.ContrailColor;
-				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
+				contrail = new ContrailRenderable(world, color, info.ContrailEndColor, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset,
+					info.ContrailFadeWithColor, info.ContrailFadeWithWidth, info.ContrailFadeWithWidthRate);
 			}
 
 			trailPalette = info.TrailPalette;

--- a/OpenRA.Mods.AS/Duplicates/Projectiles/MissileTA.cs
+++ b/OpenRA.Mods.AS/Duplicates/Projectiles/MissileTA.cs
@@ -142,16 +142,15 @@ namespace OpenRA.Mods.Common.Projectiles
 		public readonly bool TrailWhenDeactivated = false;
 
 		public readonly int ContrailLength = 0;
-
 		public readonly int ContrailZOffset = 2047;
-
-		public readonly WDist ContrailWidth = new WDist(64);
-
 		public readonly Color ContrailColor = Color.White;
-
+		public readonly Color ContrailEndColor = Color.White;
 		public readonly bool ContrailUsePlayerColor = false;
-
-		public readonly int ContrailDelay = 1;
+		public readonly int ContrailDelay = 0;
+		public readonly WDist ContrailWidth = new WDist(64);
+		public readonly bool ContrailFadeWithColor = true;
+		public readonly bool ContrailFadeWithWidth = false;
+		public readonly float ContrailFadeWithWidthRate = 1f;
 
 		[Desc("Should missile targeting be thrown off by nearby actors with JamsMissiles.")]
 		public readonly bool Jammable = true;
@@ -284,7 +283,8 @@ namespace OpenRA.Mods.Common.Projectiles
 			if (info.ContrailLength > 0)
 			{
 				var color = info.ContrailUsePlayerColor ? ContrailRenderable.ChooseColor(args.SourceActor) : info.ContrailColor;
-				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
+				contrail = new ContrailRenderable(world, color, info.ContrailEndColor, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset,
+					info.ContrailFadeWithColor, info.ContrailFadeWithWidth, info.ContrailFadeWithWidthRate);
 			}
 
 			trailPalette = info.TrailPalette;


### PR DESCRIPTION
Add 2 useful feature to contrail:
1. lerp between 2 color (start color, end color)
2. can fade in wide
![bulletline-preview](https://user-images.githubusercontent.com/13763394/157063115-583bb321-eee1-49d5-967b-0806582c81ad.gif)
![Plasma-preview2](https://user-images.githubusercontent.com/13763394/157063355-5fa40e87-ac29-4398-9469-9c4bcee4a4c9.gif)
![plasma-preview](https://user-images.githubusercontent.com/13763394/157063488-e95bed57-9184-484d-ae74-80fc6d3b7af6.gif)
![Artillery-preview](https://user-images.githubusercontent.com/13763394/157063507-0a5f9147-aefb-45eb-9219-ac54ce2eecba.gif)
![acid-preview](https://user-images.githubusercontent.com/13763394/157063514-7d544b7e-6142-4305-a09c-4f4e16a6677f.gif)
![cannon-preview](https://user-images.githubusercontent.com/13763394/157063520-bbc1bc37-27fb-4cec-9507-9ab78137dbd7.gif)

