### PR TITLE
AI-Activity overhual: activity tag for AI judging

### DIFF
--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -19,6 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Activities
 {
 	public enum ActivityState { Queued, Active, Canceling, Done }
+	public enum ActivityType { Undefined, Move, Attack, Ability } // Used for AI module micro-manage and judge squad combat condition
 
 	public class TargetLineNode
 	{
@@ -48,6 +49,7 @@ namespace OpenRA.Activities
 	 */
 	public abstract class Activity : IActivityInterface
 	{
+		public ActivityType ActivityType { get; protected set; }
 		public ActivityState State { get; private set; }
 
 		Activity childActivity;
@@ -88,6 +90,7 @@ namespace OpenRA.Activities
 
 		public Activity()
 		{
+			ActivityType = ActivityType.Undefined;
 			IsInterruptible = true;
 			ChildHasPriority = true;
 		}

--- a/OpenRA.Game/Activities/CallFunc.cs
+++ b/OpenRA.Game/Activities/CallFunc.cs
@@ -18,6 +18,7 @@ namespace OpenRA.Activities
 		public CallFunc(Action a) { this.a = a; }
 		public CallFunc(Action a, bool interruptible)
 		{
+			ActivityType = ActivityType.Undefined;
 			this.a = a;
 			IsInterruptible = interruptible;
 		}

--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -35,6 +35,7 @@ namespace OpenRA.Mods.Cnc.Activities
 
 		public LayMines(Actor self, List<CPos> minefield = null)
 		{
+			ActivityType = ActivityType.Ability;
 			minelayer = self.Trait<Minelayer>();
 			ammoPools = self.TraitsImplementing<AmmoPool>().ToArray();
 			movement = self.Trait<IMove>();

--- a/OpenRA.Mods.Cnc/Activities/Leap.cs
+++ b/OpenRA.Mods.Cnc/Activities/Leap.cs
@@ -38,6 +38,7 @@ namespace OpenRA.Mods.Cnc.Activities
 
 		public Leap(Actor self, in Target target, Mobile mobile, Mobile targetMobile, int speed, AttackLeap attack, EdibleByLeap edible)
 		{
+			ActivityType = ActivityType.Move;
 			this.mobile = mobile;
 			this.targetMobile = targetMobile;
 			this.attack = attack;

--- a/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
+++ b/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
@@ -40,6 +40,7 @@ namespace OpenRA.Mods.Cnc.Activities
 
 		public LeapAttack(Actor self, in Target target, bool allowMovement, bool forceAttack, AttackLeap attack, AttackLeapInfo info, Color? targetLineColor = null)
 		{
+			ActivityType = ActivityType.Attack;
 			this.target = target;
 			this.targetLineColor = targetLineColor;
 			this.info = info;

--- a/OpenRA.Mods.Cnc/Activities/Teleport.cs
+++ b/OpenRA.Mods.Cnc/Activities/Teleport.cs
@@ -35,6 +35,7 @@ namespace OpenRA.Mods.Cnc.Activities
 			bool killCargo, bool screenFlash, string sound, bool interruptable = true,
 			bool killOnFailure = false, BitSet<DamageType> killDamageTypes = default(BitSet<DamageType>))
 		{
+			ActivityType = ActivityType.Move;
 			var max = teleporter.World.Map.Grid.MaximumTileSearchRange;
 			if (maximumDistance > max)
 				throw new InvalidOperationException($"Teleport distance cannot exceed the value of MaximumTileSearchRange ({max}).");

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
@@ -44,6 +44,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			public AttackTDGunboatTurretedActivity(Actor self, in Target target, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 			{
+				ActivityType = ActivityType.Attack;
 				attack = self.Trait<AttackTDGunboatTurreted>();
 				this.target = target;
 				this.forceAttack = forceAttack;

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
@@ -92,6 +92,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			public ChargeAttack(AttackTesla attack, in Target target, bool forceAttack, Color? targetLineColor = null)
 			{
+				ActivityType = ActivityType.Attack;
 				this.attack = attack;
 				this.target = target;
 				this.forceAttack = forceAttack;
@@ -151,6 +152,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			public ChargeFire(AttackTesla attack, in Target target)
 			{
+				ActivityType = ActivityType.Attack;
 				this.attack = attack;
 				this.target = target;
 			}

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -157,6 +157,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			public DetonationSequence(Actor self, MadTank mad)
 				: this(self, mad, Target.Invalid)
 			{
+				ActivityType = ActivityType.Attack;
 				assignTargetOnFirstRun = true;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
@@ -26,6 +26,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public FallToEarth(Actor self, FallsToEarthInfo info)
 		{
+			ActivityType = ActivityType.Move;
 			this.info = info;
 			IsInterruptible = false;
 			aircraft = self.Trait<Aircraft>();

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -34,11 +34,13 @@ namespace OpenRA.Mods.Common.Activities
 		public Fly(Actor self, in Target t, WDist nearEnough, WPos? initialTargetPosition = null, Color? targetLineColor = null)
 			: this(self, t, initialTargetPosition, targetLineColor)
 		{
+			ActivityType = ActivityType.Move;
 			this.nearEnough = nearEnough;
 		}
 
 		public Fly(Actor self, in Target t, WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
+			ActivityType = ActivityType.Move;
 			aircraft = self.Trait<Aircraft>();
 			target = t;
 			this.targetLineColor = targetLineColor;
@@ -56,6 +58,7 @@ namespace OpenRA.Mods.Common.Activities
 			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 			: this(self, t, initialTargetPosition, targetLineColor)
 		{
+			ActivityType = ActivityType.Move;
 			this.maxRange = maxRange;
 			this.minRange = minRange;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -39,6 +39,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public FlyAttack(Actor self, AttackSource source, in Target target, bool forceAttack, Color? targetLineColor)
 		{
+			ActivityType = ActivityType.Attack;
 			this.source = source;
 			this.target = target;
 			this.forceAttack = forceAttack;
@@ -223,6 +224,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public FlyAttackRun(Actor self, in Target t, WDist exitRange, AttackAircraft attack, Rearmable rearmable)
 		{
+			ActivityType = ActivityType.Attack;
 			ChildHasPriority = false;
 
 			target = t;
@@ -277,6 +279,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public StrafeAttackRun(Actor self, AttackAircraft attackAircraft, Aircraft aircraft, in Target t, WDist exitRange)
 		{
+			ActivityType = ActivityType.Attack;
 			ChildHasPriority = false;
 
 			target = t;

--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Mods.Common.Activities
 		public FlyFollow(Actor self, in Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition, Color? targetLineColor = null)
 		{
+			ActivityType = ActivityType.Move;
 			this.target = target;
 			aircraft = self.Trait<Aircraft>();
 			this.minRange = minRange;

--- a/OpenRA.Mods.Common/Activities/Air/FlyForward.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyForward.cs
@@ -24,6 +24,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		FlyForward(Actor self)
 		{
+			ActivityType = ActivityType.Move;
 			aircraft = self.Trait<Aircraft>();
 			cruiseAltitude = aircraft.Info.CruiseAltitude;
 		}
@@ -31,12 +32,14 @@ namespace OpenRA.Mods.Common.Activities
 		public FlyForward(Actor self, int ticks = -1)
 			: this(self)
 		{
+			ActivityType = ActivityType.Move;
 			flyTicks = ticks;
 		}
 
 		public FlyForward(Actor self, WDist distance)
 			: this(self)
 		{
+			ActivityType = ActivityType.Move;
 			remainingDistance = distance.Length;
 		}
 

--- a/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyIdle.cs
@@ -26,6 +26,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public FlyIdle(Actor self, int ticks = -1, bool idleTurn = true)
 		{
+			ActivityType = ActivityType.Move;
 			aircraft = self.Trait<Aircraft>();
 			isIdleTurner = aircraft.Info.IdleSpeed > 0 || (!aircraft.Info.CanHover && aircraft.Info.IdleSpeed < 0);
 			remainingTicks = ticks;

--- a/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
@@ -24,6 +24,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public FlyOffMap(Actor self, int endingDelay = 25)
 		{
+			ActivityType = ActivityType.Move;
 			aircraft = self.Trait<Aircraft>();
 			ChildHasPriority = false;
 			this.endingDelay = endingDelay;
@@ -32,6 +33,7 @@ namespace OpenRA.Mods.Common.Activities
 		public FlyOffMap(Actor self, in Target target, int endingDelay = 25)
 			: this(self, endingDelay)
 		{
+			ActivityType = ActivityType.Move;
 			this.target = target;
 			hasTarget = true;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -37,20 +37,22 @@ namespace OpenRA.Mods.Common.Activities
 		public Land(Actor self, WAngle? facing = null, Color? targetLineColor = null)
 			: this(self, Target.Invalid, new WDist(-1), WVec.Zero, facing, targetLineColor: targetLineColor)
 		{
+			ActivityType = ActivityType.Move;
 			assignTargetOnFirstRun = true;
 		}
 
 		public Land(Actor self, in Target target, WAngle? facing = null, Color? targetLineColor = null)
-			: this(self, target, new WDist(-1), WVec.Zero, facing, targetLineColor: targetLineColor) { }
+			: this(self, target, new WDist(-1), WVec.Zero, facing, targetLineColor: targetLineColor) { ActivityType = ActivityType.Move; }
 
 		public Land(Actor self, in Target target, WDist landRange, WAngle? facing = null, Color? targetLineColor = null)
-			: this(self, target, landRange, WVec.Zero, facing, targetLineColor: targetLineColor) { }
+			: this(self, target, landRange, WVec.Zero, facing, targetLineColor: targetLineColor) { ActivityType = ActivityType.Move; }
 
 		public Land(Actor self, in Target target, in WVec offset, WAngle? facing = null, Color? targetLineColor = null)
-			: this(self, target, WDist.Zero, offset, facing, targetLineColor: targetLineColor) { }
+			: this(self, target, WDist.Zero, offset, facing, targetLineColor: targetLineColor) { ActivityType = ActivityType.Move; }
 
 		public Land(Actor self, in Target target, WDist landRange, in WVec offset, WAngle? facing = null, CPos[] clearCells = null, Color? targetLineColor = null)
 		{
+			ActivityType = ActivityType.Move;
 			aircraft = self.Trait<Aircraft>();
 			this.target = target;
 			this.offset = offset;

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -29,6 +29,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public ReturnToBase(Actor self, Actor dest = null, bool alwaysLand = false)
 		{
+			ActivityType = ActivityType.Move;
 			this.dest = dest;
 			this.alwaysLand = alwaysLand;
 			aircraft = self.Trait<Aircraft>();

--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -21,6 +21,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public TakeOff(Actor self)
 		{
+			ActivityType = ActivityType.Move;
 			aircraft = self.Trait<Aircraft>();
 			move = self.Trait<IMove>();
 		}

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -47,6 +47,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Attack(Actor self, in Target target, bool allowMovement, bool forceAttack, Color? targetLineColor = null)
 		{
+			ActivityType = ActivityType.Attack;
 			this.target = target;
 			this.targetLineColor = targetLineColor;
 			this.forceAttack = forceAttack;

--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -28,6 +28,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public DeliverResources(Actor self, Actor targetActor = null)
 		{
+			ActivityType = ActivityType.Move;
 			movement = self.Trait<IMove>();
 			harv = self.Trait<Harvester>();
 			this.targetActor = targetActor;

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -30,11 +30,13 @@ namespace OpenRA.Mods.Common.Activities
 		public DeliverUnit(Actor self, WDist deliverRange, Color? targetLineColor)
 			: this(self, Target.Invalid, deliverRange, targetLineColor)
 		{
+			ActivityType = ActivityType.Move;
 			assignTargetOnFirstRun = true;
 		}
 
 		public DeliverUnit(Actor self, in Target destination, WDist deliverRange, Color? targetLineColor)
 		{
+			ActivityType = ActivityType.Move;
 			this.destination = destination;
 			this.deliverRange = deliverRange;
 			this.targetLineColor = targetLineColor;
@@ -74,6 +76,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			public ReleaseUnit(Actor self)
 			{
+				ActivityType = ActivityType.Move;
 				facing = self.Trait<IFacing>();
 				carryall = self.Trait<Carryall>();
 				body = self.Trait<BodyOrientation>();

--- a/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
+++ b/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public DeployForGrantedCondition(Actor self, GrantConditionOnDeploy deploy, bool moving = false)
 		{
+			ActivityType = ActivityType.Move;
 			this.deploy = deploy;
 			this.moving = moving;
 			canTurn = self.Info.HasTraitInfo<IFacingInfo>();
@@ -52,6 +53,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public DeployInner(Actor self, GrantConditionOnDeploy deployment)
 		{
+			ActivityType = ActivityType.Move;
 			this.deployment = deployment;
 
 			// Once deployment animation starts, the animation must finish.

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -33,6 +33,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected Enter(Actor self, in Target target, Color? targetLineColor = null)
 		{
+			ActivityType = ActivityType.Move;
 			move = self.Trait<IMove>();
 			this.target = target;
 			this.targetLineColor = targetLineColor;

--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -36,6 +36,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public FindAndDeliverResources(Actor self, Actor deliverActor = null)
 		{
+			ActivityType = ActivityType.Move;
 			harv = self.Trait<Harvester>();
 			harvInfo = self.Info.TraitInfo<HarvesterInfo>();
 			mobile = self.Trait<Mobile>();
@@ -46,6 +47,7 @@ namespace OpenRA.Mods.Common.Activities
 		public FindAndDeliverResources(Actor self, CPos orderLocation)
 			: this(self, null)
 		{
+			ActivityType = ActivityType.Move;
 			this.orderLocation = orderLocation;
 		}
 

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public HarvestResource(Actor self, CPos targetCell)
 		{
+			ActivityType = ActivityType.Move;
 			harv = self.Trait<Harvester>();
 			harvInfo = self.Info.TraitInfo<HarvesterInfo>();
 			facing = self.Trait<IFacing>();

--- a/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
@@ -35,6 +35,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public HarvesterDockSequence(Actor self, Actor refinery, WAngle dockAngle, bool isDragRequired, in WVec dragOffset, int dragLength)
 		{
+			ActivityType = ActivityType.Move;
 			dockingState = DockingState.Turn;
 			Refinery = refinery;
 			DockAngle = dockAngle;

--- a/OpenRA.Mods.Common/Activities/Hunt.cs
+++ b/OpenRA.Mods.Common/Activities/Hunt.cs
@@ -24,6 +24,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Hunt(Actor self)
 		{
+			ActivityType = ActivityType.Move;
 			move = self.Trait<IMove>();
 			var attack = self.Trait<AttackBase>();
 			targets = self.World.ActorsHavingTrait<Huntable>().Where(

--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public AttackMoveActivity(Actor self, Func<Activity> getMove, bool assaultMoving = false)
 		{
+			ActivityType = ActivityType.Move;
 			this.getMove = getMove;
 			autoTarget = self.TraitOrDefault<AutoTarget>();
 			attackMove = self.TraitOrDefault<AttackMove>();

--- a/OpenRA.Mods.Common/Activities/Move/Drag.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Drag.cs
@@ -29,6 +29,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Drag(Actor self, WPos start, WPos end, int length, WAngle? facing = null)
 		{
+			ActivityType = ActivityType.Move;
 			positionable = self.Trait<IPositionable>();
 			disableable = self.TraitOrDefault<IMove>() as IDisabledTrait;
 			this.start = start;

--- a/OpenRA.Mods.Common/Activities/Move/Follow.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Follow.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Mods.Common.Activities
 		public Follow(Actor self, in Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition, Color? targetLineColor = null)
 		{
+			ActivityType = ActivityType.Move;
 			this.target = target;
 			this.minRange = minRange;
 			this.maxRange = maxRange;

--- a/OpenRA.Mods.Common/Activities/Move/LocalMoveIntoTarget.cs
+++ b/OpenRA.Mods.Common/Activities/Move/LocalMoveIntoTarget.cs
@@ -27,6 +27,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public LocalMoveIntoTarget(Actor self, in Target target, WDist targetMovementThreshold, Color? targetLineColor = null)
 		{
+			ActivityType = ActivityType.Move;
 			mobile = self.Trait<Mobile>();
 			this.target = target;
 			this.targetMovementThreshold = targetMovementThreshold;

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -54,6 +54,8 @@ namespace OpenRA.Mods.Common.Activities
 		// Ignores lane bias
 		public Move(Actor self, CPos destination, Color? targetLineColor = null)
 		{
+			ActivityType = ActivityType.Move;
+
 			// PERF: Because we can be sure that OccupiesSpace is Mobile here, we can save some performance by avoiding querying for the trait.
 			mobile = (Mobile)self.OccupiesSpace;
 
@@ -72,6 +74,8 @@ namespace OpenRA.Mods.Common.Activities
 		public Move(Actor self, CPos destination, WDist nearEnough, Actor ignoreActor = null, bool evaluateNearestMovableCell = false,
 			Color? targetLineColor = null)
 		{
+			ActivityType = ActivityType.Move;
+
 			// PERF: Because we can be sure that OccupiesSpace is Mobile here, we can save some performance by avoiding querying for the trait.
 			mobile = (Mobile)self.OccupiesSpace;
 
@@ -94,6 +98,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Move(Actor self, Func<BlockedByActor, List<CPos>> getPath, Color? targetLineColor = null)
 		{
+			ActivityType = ActivityType.Move;
+
 			// PERF: Because we can be sure that OccupiesSpace is Mobile here, we can save some performance by avoiding querying for the trait.
 			mobile = (Mobile)self.OccupiesSpace;
 
@@ -368,6 +374,7 @@ namespace OpenRA.Mods.Common.Activities
 			public MovePart(Move move, WPos from, WPos to, WAngle fromFacing, WAngle toFacing,
 				WRot? fromTerrainOrientation, WRot? toTerrainOrientation, int terrainOrientationMargin, int carryoverProgress)
 			{
+				ActivityType = ActivityType.Move;
 				Move = move;
 				From = from;
 				To = to;

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -33,6 +33,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public MoveAdjacentTo(Actor self, in Target target, WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
+			ActivityType = ActivityType.Move;
 			this.target = target;
 			this.targetLineColor = targetLineColor;
 			Mobile = self.Trait<Mobile>();

--- a/OpenRA.Mods.Common/Activities/Parachute.cs
+++ b/OpenRA.Mods.Common/Activities/Parachute.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Parachute(Actor self)
 		{
+			ActivityType = ActivityType.Move;
 			pos = self.TraitOrDefault<IPositionable>();
 
 			fallVector = new WVec(0, 0, self.Info.TraitInfo<ParachutableInfo>().FallRate);

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -36,6 +36,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public PickupUnit(Actor self, Actor cargo, int delay, Color? targetLineColor)
 		{
+			ActivityType = ActivityType.Move;
 			this.cargo = cargo;
 			this.delay = delay;
 			this.targetLineColor = targetLineColor;
@@ -130,6 +131,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			public AttachUnit(Actor self, Actor cargo)
 			{
+				ActivityType = ActivityType.Move;
 				this.cargo = cargo;
 				carryable = cargo.Trait<Carryable>();
 				carryall = self.Trait<Carryall>();

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -45,6 +45,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Resupply(Actor self, Actor host, WDist closeEnough, bool stayOnResupplier = false)
 		{
+			ActivityType = ActivityType.Move;
 			this.host = Target.FromActor(host);
 			this.closeEnough = closeEnough;
 			this.stayOnResupplier = stayOnResupplier;

--- a/OpenRA.Mods.Common/Activities/Sell.cs
+++ b/OpenRA.Mods.Common/Activities/Sell.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Sell(Actor self, bool showTicks)
 		{
+			ActivityType = ActivityType.Ability;
 			this.showTicks = showTicks;
 			health = self.TraitOrDefault<IHealth>();
 			sellableInfo = self.Info.TraitInfo<SellableInfo>();

--- a/OpenRA.Mods.Common/Activities/SimpleTeleport.cs
+++ b/OpenRA.Mods.Common/Activities/SimpleTeleport.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly CPos destination;
 
-		public SimpleTeleport(CPos destination) { this.destination = destination; }
+		public SimpleTeleport(CPos destination) { ActivityType = ActivityType.Move; this.destination = destination; }
 
 		public override bool Tick(Actor self)
 		{

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -34,6 +34,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Transform(string toActor)
 		{
+			ActivityType = ActivityType.Ability;
 			ToActor = toActor;
 		}
 
@@ -160,6 +161,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public IssueOrderAfterTransform(string orderString, in Target target, Color? targetLineColor = null)
 		{
+			ActivityType = ActivityType.Ability;
 			this.orderString = orderString;
 			this.target = target;
 			this.targetLineColor = targetLineColor;

--- a/OpenRA.Mods.Common/Activities/Turn.cs
+++ b/OpenRA.Mods.Common/Activities/Turn.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Turn(Actor self, WAngle desiredFacing)
 		{
+			ActivityType = ActivityType.Move;
 			mobile = self.TraitOrDefault<Mobile>();
 			facing = self.Trait<IFacing>();
 			this.desiredFacing = desiredFacing;

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -34,11 +34,13 @@ namespace OpenRA.Mods.Common.Activities
 		public UnloadCargo(Actor self, WDist unloadRange, bool unloadAll = true)
 			: this(self, Target.Invalid, unloadRange, unloadAll)
 		{
+			ActivityType = ActivityType.Move;
 			assignTargetOnFirstRun = true;
 		}
 
 		public UnloadCargo(Actor self, in Target destination, WDist unloadRange, bool unloadAll = true)
 		{
+			ActivityType = ActivityType.Move;
 			this.self = self;
 			cargo = self.Trait<Cargo>();
 			notifiers = self.TraitsImplementing<INotifyUnload>().ToArray();

--- a/OpenRA.Mods.Common/Activities/Wait.cs
+++ b/OpenRA.Mods.Common/Activities/Wait.cs
@@ -18,9 +18,10 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		int remainingTicks;
 
-		public Wait(int period) { remainingTicks = period; }
+		public Wait(int period) { ActivityType = ActivityType.Undefined; remainingTicks = period; }
 		public Wait(int period, bool interruptible)
 		{
+			ActivityType = ActivityType.Undefined;
 			remainingTicks = period;
 			IsInterruptible = interruptible;
 		}
@@ -38,9 +39,10 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Func<bool> f;
 
-		public WaitFor(Func<bool> f) { this.f = f; }
+		public WaitFor(Func<bool> f) { this.f = f; ActivityType = ActivityType.Undefined; }
 		public WaitFor(Func<bool> f, bool interruptible)
 		{
+			ActivityType = ActivityType.Undefined;
 			this.f = f;
 			IsInterruptible = interruptible;
 		}

--- a/OpenRA.Mods.Common/Scripting/CallLuaFunc.cs
+++ b/OpenRA.Mods.Common/Scripting/CallLuaFunc.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public CallLuaFunc(LuaFunction function, ScriptContext context)
 		{
+			ActivityType = ActivityType.Undefined;
 			this.function = (LuaFunction)function.CopyReference();
 			this.context = context;
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -230,6 +230,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public AttackActivity(Actor self, in Target target, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 			{
+				ActivityType = ActivityType.Attack;
 				attack = self.Trait<AttackFollow>();
 				move = allowMove ? self.TraitOrDefault<IMove>() : null;
 				revealsShroud = self.TraitsImplementing<RevealsShroud>().ToArray();

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -42,6 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public SetTarget(AttackOmni attack, in Target target, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 			{
+				ActivityType = ActivityType.Attack;
 				this.target = target;
 				this.targetLineColor = targetLineColor;
 				this.attack = attack;

--- a/OpenRA.Mods.Common/Traits/AutoCarryall.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryall.cs
@@ -110,6 +110,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public FerryUnit(Actor self, Actor cargo)
 			{
+				ActivityType = ActivityType.Move;
 				this.cargo = cargo;
 				carryable = cargo.Trait<Carryable>();
 				carryallInfo = self.Trait<Carryall>().Info;

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Traits;
 
@@ -84,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			var isFiring = false;
 			var tryAttacking = false;
 			var activity = a.CurrentActivity;
-			var type = activity.GetType();
+			var type = activity.ActivityType;
 
 			var arms = a.TraitsImplementing<Armament>();
 			var isValid = false;
@@ -103,7 +104,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			if (!isValid)
 				return (false, false);
 
-			if (type == typeof(Attack) || type == typeof(AttackFollow.AttackActivity) || type == typeof(FlyAttack))
+			if (type == ActivityType.Attack)
 			{
 				tryAttacking = true;
 
@@ -112,8 +113,8 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 					isFiring = true;
 				else
 				{
-					var childType = childActivity.GetType();
-					if (childType != typeof(MoveWithinRange) && childType != typeof(Fly))
+					var childType = childActivity.ActivityType;
+					if (childType != ActivityType.Move)
 						isFiring = true;
 				}
 			}

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -661,6 +661,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public ReturnToCellActivity(Actor self, int delay = 0, bool recalculateSubCell = false)
 			{
+				ActivityType = ActivityType.Move;
 				mobile = self.Trait<Mobile>();
 				IsInterruptible = false;
 				this.delay = delay;

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -42,6 +42,7 @@ namespace OpenRA.Mods.D2k.Activities
 
 		public SwallowActor(Actor self, in Target target, Armament a, IFacing facing)
 		{
+			ActivityType = ActivityType.Attack;
 			this.target = target;
 			this.facing = facing;
 			armament = a;


### PR DESCRIPTION
(Warning: a wide fix, although I try my best to make it conflicts less in the future merging)
An attempt to solve [this](https://github.com/OpenRA/OpenRA/issues/19844). Already used by TA, due to TA has many its own attack activity which was badly judged in AI when attack.

Now we will have AttackFolowFrontal so we need this too to make AI know when unit related is attacking