### PR TITLE
Disable "Avoid the cliff edge" to fix openra missile bug

### DIFF
--- a/OpenRA.Mods.AS/Duplicates/Projectiles/MissileTA.cs
+++ b/OpenRA.Mods.AS/Duplicates/Projectiles/MissileTA.cs
@@ -749,6 +749,9 @@ namespace OpenRA.Mods.TA.Projectiles
 
 							// TODO: deceleration checks!!!
 						}
+
+						/* TODO: I don't konw if we need this "Avoid the cliff edge" here, due to it makes missile behave stange on slope and cliff
+						 * while affecting gameplay severely.
 						else
 						{
 							// Avoid the cliff edge
@@ -766,7 +769,6 @@ namespace OpenRA.Mods.TA.Projectiles
 									if (edgeVector.Length <= loopRadius)
 										break;
 								}
-
 								desiredVFacing = vFac;
 							}
 							else
@@ -777,7 +779,8 @@ namespace OpenRA.Mods.TA.Projectiles
 								if (desiredVFacing < 0 && info.VerticalRateOfTurn.Facing < (sbyte)vFacing)
 									desiredVFacing = 0;
 							}
-						}
+					}
+						*/
 					}
 					else
 					{


### PR DESCRIPTION
The bug:
![bug](https://user-images.githubusercontent.com/13763394/180601568-e0cf98b4-72b6-4bf2-bb4c-133c64a9877d.gif)

this bug can also happen in OpenRA-TS, you can set the missile speed to 300+ and vertical speed change to 100+ to make this bug happens frequently, like now we do in sp and rv.
