### PR TITLE
Avoid using PathExistsForLocomotor for a crash happens

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -227,30 +227,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		internal Actor FindClosestEnemy(Actor leader, WDist radius)
 		{
-			var mobile = leader.TraitOrDefault<Mobile>();
-			if (mobile == null)
-				return World.FindActorsInCircle(leader.CenterPosition, radius).Where(a => IsPreferredEnemyUnit(a) && IsNotHiddenUnit(a) && IsNotUnseenUnit(a)).ClosestTo(leader.CenterPosition);
-			else
-			{
-				var locomotor = mobile.Locomotor;
-				return World.FindActorsInCircle(leader.CenterPosition, radius).Where(a => IsPreferredEnemyUnit(a) && IsNotHiddenUnit(a) && IsNotUnseenUnit(a) && mobile.PathFinder.PathExistsForLocomotor(locomotor, leader.Location, a.Location)).ClosestTo(leader.CenterPosition);
-			}
+			return World.FindActorsInCircle(leader.CenterPosition, radius).Where(a => IsPreferredEnemyUnit(a) && IsNotHiddenUnit(a) && IsNotUnseenUnit(a)).ClosestTo(leader.CenterPosition);
 		}
 
 		internal Actor FindClosestEnemy(Actor leader)
 		{
-			var mobile = leader.TraitOrDefault<Mobile>();
-			if (mobile == null)
-			{
-				var units = World.Actors.Where(a => IsPreferredEnemyUnit(a));
-				return units.Where(IsNotHiddenUnit).ClosestTo(leader.CenterPosition) ?? units.ClosestTo(leader.CenterPosition);
-			}
-			else
-			{
-				var locomotor = mobile.Locomotor;
-				var units = World.Actors.Where(a => IsPreferredEnemyUnit(a) && mobile.PathFinder.PathExistsForLocomotor(locomotor, leader.Location, a.Location));
-				return units.Where(IsNotHiddenUnit).ClosestTo(leader.CenterPosition) ?? units.ClosestTo(leader.CenterPosition);
-			}
+			var units = World.Actors.Where(a => IsPreferredEnemyUnit(a));
+			return units.Where(IsNotHiddenUnit).ClosestTo(leader.CenterPosition) ?? units.ClosestTo(leader.CenterPosition);
 		}
 
 		void CleanSquads()


### PR DESCRIPTION
Using PathExistsForLocomotor will cause crashes.

```
OpenRA engine version 8db5ef6
Shattered Paradise mod version 8db5ef6
on map d92505e9f538ae9d0ab06982f316944516697ef7 (Way to Uganda by Morton).
Date: 2022-08-16 09:42:34Z
Operating System: Windows (Microsoft Windows NT 10.0.19043.0)
Runtime Version: .NET CLR 6.0.1
Exception of type `System.IndexOutOfRangeException`: Index was outside the bounds of the array.
   at OpenRA.Mods.Common.Pathfinder.HierarchicalPathFinder.PathExists(CPos source, CPos target) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Pathfinder\HierarchicalPathFinder.cs:line 749
   at OpenRA.Mods.Common.Traits.PathFinder.PathExistsForLocomotor(Locomotor locomotor, CPos source, CPos target) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Traits\World\PathFinder.cs:line 152
   at System.Linq.Utilities.<>c__DisplayClass1_0`1.<CombinePredicates>b__0(TSource x)
   at System.Linq.Enumerable.WhereEnumerableIterator`1.MoveNext()
   at OpenRA.Exts.CompareBy[T,U](IEnumerable`1 ts, Func`2 selector, Int32 modifier, Boolean throws) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Exts.cs:line 244
   at OpenRA.WorldUtils.ClosestTo(IEnumerable`1 actors, WPos pos) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\WorldUtils.cs:line 29
   at OpenRA.Mods.Common.Traits.SquadManagerBotModule.FindClosestEnemy(Actor leader) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Traits\BotModules\SquadManagerBotModule.cs:line 252
   at OpenRA.Mods.Common.Traits.BotModules.Squads.GuerrillaUnitsHitState.Tick(Squad owner) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Traits\BotModules\Squads\States\GuerrillaStates.cs:line 276
   at OpenRA.Mods.Common.Traits.SquadManagerBotModule.AssignRolesToIdleUnits(IBot bot) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Traits\BotModules\SquadManagerBotModule.cs:line 310
   at OpenRA.Mods.Common.Traits.SquadManagerBotModule.OpenRA.Mods.Common.Traits.IBotTick.BotTick(IBot bot) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Traits\BotModules\SquadManagerBotModule.cs:line 226
   at OpenRA.Mods.Common.Traits.ModularBot.<OpenRA.Traits.ITick.Tick>b__14_0() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Traits\Player\ModularBot.cs:line 95
   at OpenRA.Sync.<>c__DisplayClass14_0.<RunUnsynced>b__0() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Sync.cs:line 172
   at OpenRA.Sync.RunUnsynced[T](Boolean checkSyncHash, World world, Func`1 fn) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Sync.cs:line 205
   at OpenRA.Sync.RunUnsynced(Boolean checkSyncHash, World world, Action fn) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Sync.cs:line 173
   at OpenRA.Mods.Common.Traits.ModularBot.OpenRA.Traits.ITick.Tick(Actor self) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Traits\Player\ModularBot.cs:line 91
   at OpenRA.TraitDictionary.TraitContainer`1.ApplyToAllTimed(Action`2 action, String text) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\TraitDictionary.cs:line 313
   at OpenRA.World.Tick() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\World.cs:line 443
   at OpenRA.Game.InnerLogicTick(OrderManager orderManager) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs:line 636
   at OpenRA.Game.LogicTick() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs:line 651
   at OpenRA.Game.Loop() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs:line 816
   at OpenRA.Game.Run() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs:line 869
   at OpenRA.Game.InitializeAndRun(String[] args) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs:line 308
   at OpenRA.Launcher.Program.Main(String[] args) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Launcher\Program.cs:line 32
```

Before I find the causes we should disable it for now.