### PR TITLE
Revert "Avoid using PathExistsForLocomotor for a crash that happen"

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
+++ b/OpenRA.Mods.Common/Pathfinder/HierarchicalPathFinder.cs
@@ -749,6 +749,9 @@ namespace OpenRA.Mods.Common.Pathfinder
 			if (costEstimator == null)
 				return false;
 
+			if (!world.Map.Contains(source) || !world.Map.Contains(target))
+				return false;
+
 			RebuildDomains();
 
 			var sourceGridInfo = gridInfos[GridIndex(source)];

--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -227,13 +227,30 @@ namespace OpenRA.Mods.Common.Traits
 
 		internal Actor FindClosestEnemy(Actor leader, WDist radius)
 		{
-			return World.FindActorsInCircle(leader.CenterPosition, radius).Where(a => IsPreferredEnemyUnit(a) && IsNotHiddenUnit(a) && IsNotUnseenUnit(a)).ClosestTo(leader.CenterPosition);
+			var mobile = leader.TraitOrDefault<Mobile>();
+			if (mobile == null)
+				return World.FindActorsInCircle(leader.CenterPosition, radius).Where(a => IsPreferredEnemyUnit(a) && IsNotHiddenUnit(a) && IsNotUnseenUnit(a)).ClosestTo(leader.CenterPosition);
+			else
+			{
+				var locomotor = mobile.Locomotor;
+				return World.FindActorsInCircle(leader.CenterPosition, radius).Where(a => IsPreferredEnemyUnit(a) && IsNotHiddenUnit(a) && IsNotUnseenUnit(a) && mobile.PathFinder.PathExistsForLocomotor(locomotor, leader.Location, a.Location)).ClosestTo(leader.CenterPosition);
+			}
 		}
 
 		internal Actor FindClosestEnemy(Actor leader)
 		{
-			var units = World.Actors.Where(a => IsPreferredEnemyUnit(a));
-			return units.Where(IsNotHiddenUnit).ClosestTo(leader.CenterPosition) ?? units.ClosestTo(leader.CenterPosition);
+			var mobile = leader.TraitOrDefault<Mobile>();
+			if (mobile == null)
+			{
+				var units = World.Actors.Where(a => IsPreferredEnemyUnit(a));
+				return units.Where(IsNotHiddenUnit).ClosestTo(leader.CenterPosition) ?? units.ClosestTo(leader.CenterPosition);
+			}
+			else
+			{
+				var locomotor = mobile.Locomotor;
+				var units = World.Actors.Where(a => IsPreferredEnemyUnit(a) && mobile.PathFinder.PathExistsForLocomotor(locomotor, leader.Location, a.Location));
+				return units.Where(IsNotHiddenUnit).ClosestTo(leader.CenterPosition) ?? units.ClosestTo(leader.CenterPosition);
+			}
 		}
 
 		void CleanSquads()


### PR DESCRIPTION
~~After [this branch](https://github.com/OpenRA/OpenRA/pull/20199) is merged upstream, we can restore this to avoid pathfinding perf lag for RV map that with large water field.~~

I want this fix quicker