### PR TITLE
Check valid relationship for weapon

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -105,6 +105,9 @@ namespace OpenRA.GameRules
 		[Desc("Number of shots in a single ammo magazine.")]
 		public readonly int Burst = 1;
 
+		[Desc("What player relationships are affected.")]
+		public readonly PlayerRelationship ValidRelationships = PlayerRelationship.Ally | PlayerRelationship.Neutral | PlayerRelationship.Enemy;
+
 		[Desc("What types of targets are affected.")]
 		public readonly BitSet<TargetableType> ValidTargets = new BitSet<TargetableType>("Ground", "Water");
 
@@ -212,8 +215,11 @@ namespace OpenRA.GameRules
 		/// <summary>Checks if the weapon is valid against (can target) the actor.</summary>
 		public bool IsValidAgainst(Actor victim, Actor firedBy)
 		{
-			var targetTypes = victim.GetEnabledTargetTypes();
+			var relationship = firedBy.Owner.RelationshipWith(victim.Owner);
+			if (!ValidRelationships.HasRelationship(relationship))
+				return false;
 
+			var targetTypes = victim.GetEnabledTargetTypes();
 			if (!IsValidTarget(targetTypes))
 				return false;
 
@@ -228,6 +234,10 @@ namespace OpenRA.GameRules
 		/// <summary>Checks if the weapon is valid against (can target) the frozen actor.</summary>
 		public bool IsValidAgainst(FrozenActor victim, Actor firedBy)
 		{
+			var relationship = firedBy.Owner.RelationshipWith(victim.Owner);
+			if (!ValidRelationships.HasRelationship(relationship))
+				return false;
+
 			if (!IsValidTarget(victim.TargetTypes))
 				return false;
 


### PR DESCRIPTION
This can be a solution on fixing `AttackFollow` ignore `Armament`'s `TargetRelationship`. With this, turreted unit with both heal and damage weapons can be set to behave normally. Like the drone below
![repair-showcase1](https://user-images.githubusercontent.com/13763394/194738031-f102969d-914c-4261-94a4-a1b92a635615.gif)
