### PR TITLE
SendOrders() fix

### DIFF
--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -212,8 +212,8 @@ namespace OpenRA.Network
 		{
 			if (GameStarted && GameSaveLastFrame < NetFrameNumber && sentOrdersFrame < NetFrameNumber)
 			{
-				Connection.Send(NetFrameNumber, localOrders.Where(o => !o.IsImmediate));
-				localOrders.RemoveAll(o => !o.IsImmediate);
+				Connection.Send(NetFrameNumber, localOrders);
+				localOrders.Clear();
 				sentOrdersFrame = NetFrameNumber;
 			}
 		}


### PR DESCRIPTION
We already have had `SendImmediateOrders()` to send immediate orders and `localImmediateOrders` to store immediate orders so those lines can be updated to upstream version