### PR TITLE
Revert "Fix desync caused by order parsing difference between local a…

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA
@@ -226,40 +225,6 @@ namespace OpenRA
 
 				return null;
 			}
-		}
-
-		public static Order RefreshOrder(Order order)
-		{
-			if (order.Type != OrderType.Fields)
-				return order;
-
-			if (order.Subject != null && !order.Subject.IsInWorld)
-				return null;
-
-			var target = Target.Invalid;
-			Actor[] extraActors = null;
-			Actor[] groupedActors = null;
-
-			if (order.target.Type == TargetType.Actor)
-			{
-				if (order.target.Actor != null && order.target.Actor.IsInWorld)
-					target = order.target;
-			}
-			else if (order.target.Type == TargetType.FrozenActor)
-			{
-				if (order.target.FrozenActor != null)
-					target = order.target;
-			}
-			else
-				target = order.target;
-
-			if (order.ExtraActors != null)
-				extraActors = order.ExtraActors.Where(a => a != null && a.IsInWorld).ToArray();
-
-			if (order.GroupedActors != null)
-				groupedActors = order.GroupedActors.Where(a => a != null && a.IsInWorld).ToArray();
-
-			return new Order(order.OrderString, order.Subject, target, order.TargetString, order.Queued, extraActors, order.ExtraLocation, order.ExtraData, groupedActors);
 		}
 
 		static uint UIntFromActor(Actor a)

--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -33,10 +33,7 @@ namespace OpenRA.Network
 
 		public IEnumerable<Order> GetOrders(World world)
 		{
-			if (orders == null)
-				return ParseData(world);
-			else
-				return RefreshedOrders();
+			return orders ?? ParseData(world);
 		}
 
 		IEnumerable<Order> ParseData(World world)
@@ -50,22 +47,6 @@ namespace OpenRA.Network
 			while (data.Position < data.Length)
 			{
 				var o = Order.Deserialize(world, reader);
-				if (o != null)
-					yield return o;
-			}
-		}
-
-		// We check if orders are valid (related actors must in world)
-		// before executing, in order to keep consistent with ParseData()
-		// used by other clients.
-		IEnumerable<Order> RefreshedOrders()
-		{
-			if (orders == null)
-				yield break;
-
-			foreach (var order in orders)
-			{
-				var o = Order.RefreshOrder(order);
 				if (o != null)
 					yield return o;
 			}


### PR DESCRIPTION
Upstream decide to take a different approach: revert the optimazation that local order will not be serialized and deserialized. So my method is reverted here, for better maintain in the future.

Suggest a rebase to the upstream after this PR is merged, otherwise the mutiplayer game will be not stable, especially for AI.