### PR TITLE
Fix dvide 0 crash in WarheadTrailProjectile

### DIFF
--- a/OpenRA.Mods.AS/Projectiles/WarheadTrailProjectile.cs
+++ b/OpenRA.Mods.AS/Projectiles/WarheadTrailProjectile.cs
@@ -265,8 +265,9 @@ namespace OpenRA.Mods.AS.Projectiles
 		WPos GetTargetPos()
 		{
 			var targetpos = args.PassiveTarget;
+			var div = (targetpos - sourcepos).Length;
 
-			return WPos.Lerp(sourcepos, targetpos, args.Weapon.Range.Length, (targetpos - sourcepos).Length);
+			return WPos.Lerp(sourcepos, targetpos, args.Weapon.Range.Length, div > 0 ? div : 1);
 		}
 
 		public void Tick(World world)


### PR DESCRIPTION
It is possible that `targetpos` = `sourcepos`, and result in crash on this projectile


```
OpenRA engine version 7f3a922
OpenRA Language: en
Shattered Paradise mod version {DEV_VERSION}
on map d92505e9f538ae9d0ab06982f316944516697ef7 (Way to Uganda by Morton).
Date: 2023-02-15 03:56:53Z
Operating System: Windows (X64, Microsoft Windows NT 10.0.19045.0)
Runtime Version: .NET CLR 6.0.11
Installed Language: zh (Installed) zh (Current) zh (Current UI)
Exception of type `System.DivideByZeroException`: Attempted to divide by zero.
   at OpenRA.Mods.AS.Projectiles.WarheadTrailProjectile.GetTargetPos() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.AS\Projectiles\WarheadTrailProjectile.cs:line 269
   at OpenRA.Mods.AS.Projectiles.WarheadTrailProjectile..ctor(WarheadTrailProjectileInfo info, ProjectileArgs args) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.AS\Projectiles\WarheadTrailProjectile.cs:line 192
   at OpenRA.Mods.AS.Projectiles.WarheadTrailProjectileInfo.Create(ProjectileArgs args) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.AS\Projectiles\WarheadTrailProjectile.cs:line 143
   at OpenRA.Mods.Common.Traits.Armament.<>c__DisplayClass35_0.<FireBarrel>b__2(Int32 burst) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Traits\Armament.cs:line 405
   at OpenRA.Mods.Common.Traits.Armament.ScheduleDelayedAction(Int32 t, Int32 b, Action`1 a) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Traits\Armament.cs:line 281
   at OpenRA.Mods.Common.Traits.Armament.FireBarrel(Actor self, IFacing facing, Target& target, Barrel barrel) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Traits\Armament.cs:line 401
   at OpenRA.Mods.Common.Traits.Armament.CheckFire(Actor self, IFacing facing, Target& target) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Traits\Armament.cs:line 305
   at OpenRA.Mods.Common.Activities.Attack.DoAttack(Actor self, AttackFrontal attack, IEnumerable`1 armaments) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Activities\Attack.cs:line 240
   at OpenRA.Mods.Common.Activities.Attack.TickAttack(Actor self, AttackFrontal attack) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Activities\Attack.cs:line 233
   at OpenRA.Mods.Common.Activities.Attack.Tick(Actor self) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.Common\Activities\Attack.cs:line 145
   at OpenRA.Activities.Activity.TickOuter(Actor self) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Activities\Activity.cs:line 111
   at OpenRA.Traits.ActivityUtils.RunActivity(Actor self, Activity act) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Traits\ActivityUtils.cs:line 31
   at OpenRA.Actor.Tick() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Actor.cs:line 262
   at OpenRA.World.Tick() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\World.cs:line 441
   at OpenRA.Game.InnerLogicTick(OrderManager orderManager) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs:line 639
   at OpenRA.Game.LogicTick() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs:line 654
   at OpenRA.Game.Loop() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs:line 823
   at OpenRA.Game.Run() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs:line 876
   at OpenRA.Game.InitializeAndRun(String[] args) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs:line 311
   at OpenRA.Launcher.Program.Main(String[] args) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Launcher\Program.cs:line 32
```