### PR TITLE
Remove exception throwing from AddInfluence and have PickupUnit run a TakeOff activity

### DIFF
--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -66,15 +66,12 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override bool Tick(Actor self)
 		{
-			if (cargo != carryall.Carryable)
-				return true;
-
 			if (IsCanceling)
 			{
 				if (carryall.State == Carryall.CarryallState.Reserved)
 					carryall.UnreserveCarryable(self);
 
-				// Make sure we run the TakeOff activity if we are / have landed
+				// Make sure we run the TakeOff activity if we are/have landed
 				if (self.Trait<Aircraft>().HasInfluence())
 				{
 					ChildHasPriority = true;
@@ -86,10 +83,11 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 			}
 
-			if (cargo.IsDead || carryable.IsTraitDisabled || !cargo.AppearsFriendlyTo(self))
+			if (cargo != carryall.Carryable || cargo.IsDead || carryable.IsTraitDisabled || !cargo.AppearsFriendlyTo(self))
 			{
 				carryall.UnreserveCarryable(self);
-				return true;
+				Cancel(self, true);
+				return false;
 			}
 
 			// Wait until we are near the target before we try to lock it
@@ -101,7 +99,10 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				var lockResponse = carryable.LockForPickup(self);
 				if (lockResponse == LockResponse.Failed)
-					Cancel(self);
+				{
+					Cancel(self, true);
+					return false;
+				}
 				else if (lockResponse == LockResponse.Success)
 				{
 					// Pickup position and facing are now known - swap the fly/wait activity with Land

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -881,8 +881,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			if (HasInfluence())
-				throw new InvalidOperationException(
-					$"Cannot {nameof(AddInfluence)} until previous influence is removed with {nameof(RemoveInfluence)}");
+				self.World.ActorMap.RemoveInfluence(self, this);
 
 			this.landingCells = landingCells;
 			if (self.IsInWorld)

--- a/OpenRA.Mods.Common/Traits/AutoCarryall.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryall.cs
@@ -212,7 +212,10 @@ namespace OpenRA.Mods.Common.Traits
 			public override bool Tick(Actor self)
 			{
 				if (cargo.IsDead)
+				{
+					carryall.UnreserveCarryable(self);
 					return true;
+				}
 
 				var dropRange = carryall.Info.DropRange;
 				var destination = carryable.Destination;

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -251,7 +251,11 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual void UnreserveCarryable(Actor self)
 		{
 			if (Carryable != null && Carryable.IsInWorld && !Carryable.IsDead)
-				Carryable.Trait<Carryable>().UnReserve();
+			{
+				var carryable = Carryable.Trait<Carryable>();
+				if (carryable.Carrier == self)
+					carryable.UnReserve();
+			}
 
 			Carryable = null;
 			State = CarryallState.Idle;


### PR DESCRIPTION
[OpenRA #20489](https://github.com/OpenRA/OpenRA/pull/20489)

This is a temporary fix in OpenRA upstream on carryall crash problem.

We need this for a stable gameplay, but we need to revert it when they have better way to fix the carryall crash