### PR TITLE
Add NoUnintendedFriendlyFire to SpreadDamageWarhead

### DIFF
--- a/OpenRA.Mods.AS/Projectiles/WarheadTrailProjectile.cs
+++ b/OpenRA.Mods.AS/Projectiles/WarheadTrailProjectile.cs
@@ -250,7 +250,7 @@ namespace OpenRA.Mods.AS.Projectiles
 					Source = offsetSourcePos,
 					CurrentSource = () => offsetSourcePos,
 					SourceActor = firedBy,
-					GuidedTarget = target,
+					GuidedTarget = args.GuidedTarget,
 					PassiveTarget = target.CenterPosition
 				};
 


### PR DESCRIPTION
In SP, there are some problem:
1. to avoid aircraft friendly fire when dog fight, we simply disable the AA damage to friendly, which looks strange (Nod's rage debuff affects little to those units) and not consistent with the rest: ground AA can still friendly fire the aircraft.
2. SP introduce the melee unit, and they are always the victim of friendly fire, especially the shark of the scrin. Using two damge warheads is expensive to solve this issue.

So I introduce `UnintendedFriendlyFire` to solve this problem, which means friendly fire happens only when attack firendly unit intendly:
![no-friendly-fire1](https://github.com/MustaphaTR/OpenRA/assets/13763394/4f242813-2f09-4d31-869e-f5245c2ac6cc)
![no-friendly-fire2](https://github.com/MustaphaTR/OpenRA/assets/13763394/7ac0e71a-0f14-4df0-859d-830948375adf)

We can attach this option to weapon that can be no friendly fire in common sense, like most of laser (especially the swiping one), most of AA weapon, acid from scrin or mutant and sonic shockwave from sonic tank (then it can be affect by rage debuff)