### PR TITLE
Add "is dead" workaround when load shared passenger

### DIFF
--- a/OpenRA.Mods.AS/Traits/SharedCargo.cs
+++ b/OpenRA.Mods.AS/Traits/SharedCargo.cs
@@ -302,6 +302,9 @@ namespace OpenRA.Mods.AS.Traits
 
 		public void Load(Actor self, Actor a)
 		{
+			if (a.IsDead)
+				return;
+
 			Manager.Cargo.Push(a);
 			var w = GetWeight(a);
 			Manager.TotalWeight += w;


### PR DESCRIPTION
Fix this
```
OpenRA engine version 5aa7f60
OpenRA Language: en
Shattered Paradise mod version {DEV_VERSION}
on map 70a15cee408d4c7eac15e2cd4f5a35e0e00d03fc (Minigame: Whack-a-mutant by Marn).
Date: 2023-06-22 11:35:31Z
Operating System: Windows (X64, Microsoft Windows NT 10.0.19045.0)
Runtime Version: .NET CLR 6.0.11
Exception of type `System.InvalidOperationException`: Attempted to get trait from destroyed object (deathclaw 40 (not in world))
   at OpenRA.TraitDictionary.CheckDestroyed(Actor actor) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\TraitDictionary.cs:line 84
   at OpenRA.Mods.AS.Traits.SharedCargo.OpenRA.Traits.ITick.Tick(Actor self) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Mods.AS\Traits\SharedCargo.cs:line 363
   at OpenRA.TraitDictionary.TraitContainer`1.ApplyToAllTimed(Action`2 action, String text) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\TraitDictionary.cs:line 313
   at OpenRA.World.Tick() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\World.cs:line 448
   at OpenRA.Game.InnerLogicTick(OrderManager orderManager) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs:line 630
   at OpenRA.Game.LogicTick() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs:line 645
   at OpenRA.Game.Loop() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs:line 814
   at OpenRA.Game.Run() in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs:line 867
   at OpenRA.Game.InitializeAndRun(String[] args) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Game\Game.cs:line 305
   at OpenRA.Launcher.Program.Main(String[] args) in D:\work\Projects\Github\shattered-paradise-sdk-mirror\engine\OpenRA.Launcher\Program.cs:line 32


```