### PR TITLE
Fix the continuous lags by activity queue a mobile-move to target

### DIFF
--- a/OpenRA.Mods.AS/Activities/UnloadSharedCargo.cs
+++ b/OpenRA.Mods.AS/Activities/UnloadSharedCargo.cs
@@ -34,6 +34,7 @@ namespace OpenRA.Mods.AS.Activities
 
 		Target destination;
 		bool takeOffAfterUnload;
+		bool wasMobileMoved = false;
 
 		public UnloadSharedCargo(Actor self, WDist unloadRange, bool unloadAll = true)
 			: this(self, Target.Invalid, unloadRange, unloadAll)
@@ -91,6 +92,7 @@ namespace OpenRA.Mods.AS.Activities
 			{
 				var cell = self.World.Map.Clamp(this.self.World.Map.CellContaining(destination.CenterPosition));
 				QueueChild(new Move(self, cell, unloadRange));
+				wasMobileMoved = true;
 			}
 
 			QueueChild(new Wait(cargo.Info.BeforeUnloadDelay));
@@ -100,6 +102,11 @@ namespace OpenRA.Mods.AS.Activities
 		{
 			if (IsCanceling || cargo.Manager.IsEmpty())
 				return true;
+
+			if (wasMobileMoved && mobile != null && mobile.MoveResult == MoveResult.MovementStuck)
+				return true;
+			else
+				wasMobileMoved = false;
 
 			if (cargo.CanUnload())
 			{

--- a/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
+++ b/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
@@ -37,6 +37,7 @@ namespace OpenRA.Mods.Cnc.Activities
 		WDist lastVisibleMaxRange;
 		BitSet<TargetableType> lastVisibleTargetTypes;
 		Player lastVisibleOwner;
+		bool wasMovingWithinRange;
 
 		public LeapAttack(Actor self, in Target target, bool allowMovement, bool forceAttack, AttackLeap attack, AttackLeapInfo info, Color? targetLineColor = null)
 		{
@@ -48,11 +49,13 @@ namespace OpenRA.Mods.Cnc.Activities
 			this.allowMovement = allowMovement;
 			this.forceAttack = forceAttack;
 			mobile = self.Trait<Mobile>();
+			if (mobile != null)
+				mobile.MoveResult = MoveResult.SoFarSoGood;
 
 			// The target may become hidden between the initial order request and the first tick (e.g. if queued)
 			// Moving to any position (even if quite stale) is still better than immediately giving up
 			if ((target.Type == TargetType.Actor && target.Actor.CanBeViewedByPlayer(self.Owner))
-			    || target.Type == TargetType.FrozenActor || target.Type == TargetType.Terrain)
+				|| target.Type == TargetType.FrozenActor || target.Type == TargetType.Terrain)
 			{
 				lastVisibleTarget = Target.FromPos(target.CenterPosition);
 				lastVisibleMinRange = attack.GetMinimumRangeVersusTarget(target);
@@ -93,6 +96,19 @@ namespace OpenRA.Mods.Cnc.Activities
 
 			useLastVisibleTarget = targetIsHiddenActor || !target.IsValidFor(self);
 
+			// If we are ticking again after previously sequencing a MoveWithRange then that move must have completed, and there is 3 situation:
+			// 1. we are in range and can see the target.
+			// 2. we've lost track of it and should give up.
+			// 3. we are stuck by immovable actors, we should give up.
+			// 4. we cannot reach the location to attack target, but we can retry.
+			if (wasMovingWithinRange)
+			{
+				if (mobile != null && mobile.MoveResult == MoveResult.MovementStuck)
+					return true;
+				else
+					wasMovingWithinRange = false;
+			}
+
 			// Target is hidden or dead, and we don't have a fallback position to move towards
 			if (useLastVisibleTarget && !lastVisibleTarget.IsValidFor(self))
 				return true;
@@ -105,6 +121,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				if (!allowMovement || lastVisibleMaxRange == WDist.Zero || lastVisibleMaxRange < lastVisibleMinRange)
 					return true;
 
+				wasMovingWithinRange = true;
 				QueueChild(mobile.MoveWithinRange(target, lastVisibleMinRange, lastVisibleMaxRange, checkTarget.CenterPosition, Color.Red));
 				return false;
 			}

--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Mods.Common.Activities
 		bool hasDeliveredLoad;
 		bool hasHarvestedCell;
 		bool hasWaited;
+		bool wasMobileMoved = false;
 
 		public bool LastSearchFailed { get; private set; }
 
@@ -40,6 +41,8 @@ namespace OpenRA.Mods.Common.Activities
 			harv = self.Trait<Harvester>();
 			harvInfo = self.Info.TraitInfo<HarvesterInfo>();
 			mobile = self.Trait<Mobile>();
+			if (mobile != null)
+				mobile.MoveResult = MoveResult.SoFarSoGood;
 			claimLayer = self.World.WorldActor.Trait<ResourceClaimLayer>();
 			this.deliverActor = deliverActor;
 		}
@@ -63,13 +66,17 @@ namespace OpenRA.Mods.Common.Activities
 				// We have to make sure the actual "harvest" order is not skipped if a third order is queued,
 				// so we keep deliveredLoad false.
 				if (harv.IsFull)
+				{
+					wasMobileMoved = true;
 					QueueChild(new DeliverResources(self));
+				}
 			}
 
 			// If an explicit "deliver" order is given, the harvester goes immediately to the refinery.
 			if (deliverActor != null)
 			{
 				QueueChild(new DeliverResources(self, deliverActor));
+				wasMobileMoved = true;
 				hasDeliveredLoad = true;
 				deliverActor = null;
 			}
@@ -79,6 +86,11 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			if (IsCanceling || harv.IsTraitDisabled)
 				return true;
+
+			if (wasMobileMoved && mobile != null && mobile.MoveResult == MoveResult.MovementStuck)
+				return true;
+			else
+				wasMobileMoved = false;
 
 			if (NextActivity != null)
 			{
@@ -96,6 +108,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				QueueChild(new DeliverResources(self));
 				hasDeliveredLoad = true;
+				wasMobileMoved = true;
 				return false;
 			}
 
@@ -138,6 +151,7 @@ namespace OpenRA.Mods.Common.Activities
 					{
 						var unblockCell = self.World.Map.CellContaining(deliveryLoc) + harv.Info.UnblockCell;
 						var moveTo = mobile.NearestMoveableCell(unblockCell, 1, 5);
+						wasMobileMoved = true;
 						QueueChild(mobile.MoveTo(moveTo, 1));
 					}
 				}
@@ -147,6 +161,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// If we get here, our search for resources was successful. Commence harvesting.
 			QueueChild(new HarvestResource(self, closestHarvestableCell.Value));
+			wasMobileMoved = true;
 			lastHarvestedCell = closestHarvestableCell.Value;
 			hasHarvestedCell = true;
 			return false;

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Activities
 		public WAngle ActorFacingModifier { get; private set; }
 		readonly Mobile mobile;
 		readonly WDist nearEnough;
-		readonly Func<BlockedByActor, List<CPos>> getPath;
+		readonly Func<BlockedByActor, (List<CPos> Path, bool DestinationIsStartpoint)> getPath;
 		readonly Actor ignoreActor;
 		readonly Color? targetLineColor;
 
@@ -61,8 +61,8 @@ namespace OpenRA.Mods.Common.Activities
 
 			getPath = check =>
 			{
-				return mobile.PathFinder.FindPathToTargetCell(
-					self, new[] { mobile.ToCell }, destination, check, laneBias: false);
+				return (mobile.PathFinder.FindPathToTargetCell(
+					self, new[] { mobile.ToCell }, destination, check, laneBias: false), destination == self.Location);
 			};
 
 			this.destination = destination;
@@ -81,10 +81,10 @@ namespace OpenRA.Mods.Common.Activities
 			getPath = check =>
 			{
 				if (!this.destination.HasValue)
-					return PathFinder.NoPath;
+					return (PathFinder.NoPath, false);
 
-				return mobile.PathFinder.FindPathToTargetCell(
-					self, new[] { mobile.ToCell }, this.destination.Value, check, ignoreActor: ignoreActor);
+				return (mobile.PathFinder.FindPathToTargetCell(
+					self, new[] { mobile.ToCell }, this.destination.Value, check, ignoreActor: ignoreActor), this.destination.Value == self.Location);
 			};
 
 			// Note: Will be recalculated from OnFirstRun if evaluateNearestMovableCell is true
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Activities
 			this.targetLineColor = targetLineColor;
 		}
 
-		public Move(Actor self, Func<BlockedByActor, List<CPos>> getPath, Color? targetLineColor = null)
+		public Move(Actor self, Func<BlockedByActor, (List<CPos> Path, bool DestinationIsStartpoint)> getPath, Color? targetLineColor = null)
 		{
 			ActivityType = ActivityType.Move;
 
@@ -110,15 +110,17 @@ namespace OpenRA.Mods.Common.Activities
 			this.targetLineColor = targetLineColor;
 		}
 
-		List<CPos> EvalPath(BlockedByActor check)
+		(List<CPos> Path, bool DestinationIsStartpoint) EvalPath(BlockedByActor check)
 		{
-			var path = getPath(check).TakeWhile(a => a != mobile.ToCell).ToList();
-			return path;
+			var (pathing, destinationIsStartpoint) = getPath(check);
+			var p = pathing.TakeWhile(a => a != mobile.ToCell).ToList();
+			return (p, destinationIsStartpoint);
 		}
 
 		protected override void OnFirstRun(Actor self)
 		{
 			startTicks = self.World.WorldTick;
+			mobile.MoveResult = MoveResult.SoFarSoGood;
 
 			if (evaluateNearestMovableCell && destination.HasValue)
 			{
@@ -129,9 +131,16 @@ namespace OpenRA.Mods.Common.Activities
 			// TODO: Change this to BlockedByActor.Stationary after improving the local avoidance behaviour
 			foreach (var check in PathSearchOrder)
 			{
-				path = EvalPath(check);
+				var (pathing, destinationIsStartpoint) = EvalPath(check);
+				path = pathing;
+
 				if (path.Count > 0)
 					return;
+
+				// If the terrain is not even reachable, suggest parent activity to give up
+				// HACK: see "MoveAdjacentTo.cs" -> "CalculatePathToTarget(...)" comments on why we need "destinationIsStartpoint"
+				if (check == BlockedByActor.None && !destinationIsStartpoint)
+					mobile.MoveResult = MoveResult.MovementStuck;
 			}
 		}
 
@@ -213,7 +222,7 @@ namespace OpenRA.Mods.Common.Activities
 			// Something else might have moved us, so the path is no longer valid.
 			if (!Util.AreAdjacentCells(mobile.ToCell, nextCell))
 			{
-				path = EvalPath(BlockedByActor.Immovable);
+				path = EvalPath(BlockedByActor.Immovable).Path;
 				return null;
 			}
 
@@ -254,7 +263,12 @@ namespace OpenRA.Mods.Common.Activities
 				// There is no point in waiting for the other actor to move if it is incapable of moving.
 				if (!mobile.CanEnterCell(nextCell, ignoreActor, BlockedByActor.Immovable))
 				{
-					path = EvalPath(BlockedByActor.Immovable);
+					path = EvalPath(BlockedByActor.Immovable).Path;
+
+					// If actor is blocked by immovable actors, suggest parent activiy to give up
+					if (path.Count == 0)
+						mobile.MoveResult = MoveResult.MovementStuck;
+
 					return null;
 				}
 
@@ -280,7 +294,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				// Calculate a new path
 				mobile.RemoveInfluence();
-				var newPath = EvalPath(BlockedByActor.All);
+				var newPath = EvalPath(BlockedByActor.All).Path;
 				mobile.AddInfluence();
 
 				if (newPath.Count != 0)

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -108,24 +108,35 @@ namespace OpenRA.Mods.Common.Activities
 		protected readonly List<CPos> SearchCells = new();
 
 		protected int searchCellsTick = -1;
+		protected bool destinationIsStartpoint;
 
-		protected virtual List<CPos> CalculatePathToTarget(Actor self, BlockedByActor check)
+		protected virtual (List<CPos> Path, bool DestinationIsStartpoint) CalculatePathToTarget(Actor self, BlockedByActor check)
 		{
 			// PERF: Assume that candidate cells don't change within a tick to avoid repeated queries
 			// when Move enumerates different BlockedByActor values.
 			if (searchCellsTick != self.World.WorldTick)
 			{
 				SearchCells.Clear();
+				destinationIsStartpoint = false;
 				searchCellsTick = self.World.WorldTick;
 				foreach (var cell in Util.AdjacentCells(self.World, Target))
-					if (Mobile.CanStayInCell(cell) && Mobile.CanEnterCell(cell))
-						SearchCells.Add(cell);
+				{
+					if (Mobile.CanStayInCell(cell))
+					{
+						// HACK: When Pathfinder returns an empty path, there is possibility that, the destination is the location of actor,
+						// which means the parent activity should not stop on this. We need to pick out this specific situation for "Move".
+						if (cell == self.Location)
+							destinationIsStartpoint = true;
+						if (Mobile.CanEnterCell(cell))
+							SearchCells.Add(cell);
+					}
+				}
 			}
 
 			if (SearchCells.Count == 0)
-				return PathFinder.NoPath;
+				return (PathFinder.NoPath, destinationIsStartpoint);
 
-			return Mobile.PathFinder.FindPathToTargetCells(self, self.Location, SearchCells, check);
+			return (Mobile.PathFinder.FindPathToTargetCells(self, self.Location, SearchCells, check), destinationIsStartpoint);
 		}
 
 		public override IEnumerable<Target> GetTargets(Actor self)

--- a/OpenRA.Mods.Common/Activities/Move/MoveOnto.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveOnto.cs
@@ -38,11 +38,14 @@ namespace OpenRA.Mods.Common.Activities
 			return Target.Type == TargetType.Terrain;
 		}
 
-		protected override List<CPos> CalculatePathToTarget(Actor self, BlockedByActor check)
+		protected override (List<CPos> Path, bool DestinationIsStartpoint) CalculatePathToTarget(Actor self, BlockedByActor check)
 		{
+			if (lastVisibleTargetLocation == self.Location)
+				destinationIsStartpoint = true;
+
 			// If we are close to the target but can't enter, we wait.
 			if (!Mobile.CanEnterCell(lastVisibleTargetLocation) && Util.AreAdjacentCells(lastVisibleTargetLocation, self.Location))
-				return PathFinder.NoPath;
+				return (PathFinder.NoPath, destinationIsStartpoint);
 
 			// PERF: Don't create a new list every run.
 			// PERF: Also reuse the already created list in the base class.
@@ -51,7 +54,7 @@ namespace OpenRA.Mods.Common.Activities
 			else if (SearchCells[0] != lastVisibleTargetLocation)
 				SearchCells[0] = lastVisibleTargetLocation;
 
-			return Mobile.PathFinder.FindPathToTargetCells(self, self.Location, SearchCells, check);
+			return (Mobile.PathFinder.FindPathToTargetCells(self, self.Location, SearchCells, check), destinationIsStartpoint);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -33,6 +33,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly ICallForTransport[] transportCallers;
 		readonly IMove move;
 		readonly Aircraft aircraft;
+		readonly Mobile mobile;
 		readonly IMoveInfo moveInfo;
 		readonly bool stayOnResupplier;
 		readonly bool wasRepaired;
@@ -42,6 +43,7 @@ namespace OpenRA.Mods.Common.Activities
 		int remainingTicks;
 		bool played;
 		bool actualResupplyStarted;
+		bool wasMobileMoved = false;
 		ResupplyType activeResupplyTypes = ResupplyType.None;
 
 		public Resupply(Actor self, Actor host, WDist closeEnough, bool stayOnResupplier = false)
@@ -61,6 +63,9 @@ namespace OpenRA.Mods.Common.Activities
 			transportCallers = self.TraitsImplementing<ICallForTransport>().ToArray();
 			move = self.Trait<IMove>();
 			aircraft = move as Aircraft;
+			mobile = move as Mobile;
+			if (mobile != null)
+				mobile.MoveResult = MoveResult.SoFarSoGood;
 			moveInfo = self.Info.TraitInfo<IMoveInfo>();
 			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
 
@@ -117,6 +122,11 @@ namespace OpenRA.Mods.Common.Activities
 			if (!IsCanceling && isHostInvalid)
 				Cancel(self, true);
 
+			if (wasMobileMoved && mobile != null && mobile.MoveResult == MoveResult.MovementStuck)
+				Cancel(self, true);
+			else
+				wasMobileMoved = false;
+
 			if (IsCanceling || isHostInvalid)
 			{
 				// Only tick host INotifyResupply traits one last time if host is still alive
@@ -143,6 +153,7 @@ namespace OpenRA.Mods.Common.Activities
 				else
 					QueueChild(move.MoveWithinRange(host, closeEnough, targetLineColor: moveInfo.GetTargetLineColor()));
 
+				wasMobileMoved = true;
 				var delta = (self.CenterPosition - host.CenterPosition).LengthSquared;
 				transportCallers.FirstOrDefault(t => t.MinimumDistance.LengthSquared < delta)?.RequestTransport(self, targetCell);
 
@@ -238,6 +249,7 @@ namespace OpenRA.Mods.Common.Activities
 				// If there's no next activity, move to rallypoint if available, else just leave host if Repairable.
 				// Do nothing if RepairableNear (RepairableNear actors don't enter their host and will likely remain within closeEnough).
 				// If there's a next activity and we're not RepairableNear, first leave host if the next activity is not a Move.
+				wasMobileMoved = true;
 				if (self.CurrentActivity.NextActivity == null)
 				{
 					if (rp != null && rp.Path.Count > 0)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -213,6 +213,7 @@ namespace OpenRA.Mods.Common.Traits
 		public bool IsBlocking { get; private set; }
 
 		public bool IsMovingBetweenCells => FromCell != ToCell;
+		public MoveResult MoveResult;
 
 		#region IFacing
 
@@ -801,7 +802,7 @@ namespace OpenRA.Mods.Common.Traits
 			CrushAction(self, (notifyCrushed) => notifyCrushed.WarnCrush);
 		}
 
-		public Activity MoveTo(Func<BlockedByActor, List<CPos>> pathFunc) { return new Move(self, pathFunc); }
+		public Activity MoveTo(Func<BlockedByActor, (List<CPos> Path, bool DestinationIsStartpoint)> pathFunc) { return new Move(self, pathFunc); }
 
 		Activity LocalMove(Actor self, WPos fromPos, WPos toPos, CPos cell)
 		{

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -672,6 +672,13 @@ namespace OpenRA.Mods.Common.Traits
 		Turn = 4
 	}
 
+	[Flags]
+	public enum MoveResult
+	{
+		SoFarSoGood = 0,
+		MovementStuck = 1,
+	}
+
 	[RequireExplicitImplementation]
 	public interface INotifyMoving
 	{


### PR DESCRIPTION
Hacky way to mostly solve https://github.com/MustaphaTR/Romanovs-Vengeance/issues/88, which should be similar to https://github.com/OpenRA/OpenRA/issues/20948

You can have a test by using https://github.com/OpenRA/OpenRA/pull/20954. Upstream version of this PR.

## Fix unit endlessly pathfinding when stuck on enclosed immovable actors
before:
![pathfinding-lag](https://github.com/OpenRA/OpenRA/assets/13763394/dc665e8a-88d8-4b7c-a258-da205c7f75bc)

after:
![fix](https://github.com/OpenRA/OpenRA/assets/13763394/167e059b-3d5c-44fa-82a4-5a6ca3c6087f)

## Fixx unit endlessly pathfinding when stuck on unreachable terrain
before:
![before](https://github.com/OpenRA/OpenRA/assets/13763394/b60ffdb9-0555-43e9-89e9-e06f5262c930)

after:
![after](https://github.com/OpenRA/OpenRA/assets/13763394/bc8e11b6-568e-4da0-b2c0-6a2c40e171a3)

*Need more tests to see if there is any change to regular gameplay, and I need help on that.* @MustaphaTR 