### PR TITLE
Cloak should be detected by horizontal range

### DIFF
--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -269,7 +269,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			return self.World.ActorsWithTrait<DetectCloaked>().Any(a => a.Actor.Owner.IsAlliedWith(viewer)
 				&& Info.DetectionTypes.Overlaps(a.Trait.Info.DetectionTypes)
-				&& (self.CenterPosition - a.Actor.CenterPosition).LengthSquared <= a.Trait.Range.LengthSquared);
+				&& (self.CenterPosition - a.Actor.CenterPosition).HorizontalLengthSquared <= a.Trait.Range.LengthSquared);
 		}
 
 		Color IRadarColorModifier.RadarColorOverride(Actor self, Color color)


### PR DESCRIPTION
Or it cannot work on aircraft properly, and does not match up with `RenderDetectionCircle`