### PR TITLE
Fix orderlatency in RV&SP makes AI duplicated production

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -272,6 +272,11 @@ namespace OpenRA
 			return new Order("StartProduction", subject, queued) { ExtraData = (uint)count, TargetString = item };
 		}
 
+		public static Order StartProductionAI(Actor subject, string item, int count, bool queued = true)
+		{
+			return new Order("StartProductionAI", subject, queued) { ExtraData = (uint)count, TargetString = item };
+		}
+
 		public static Order PauseProduction(Actor subject, string item, bool pause)
 		{
 			return new Order("PauseProduction", subject, false) { ExtraData = pause ? 1u : 0u, TargetString = item };

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (item == null)
 					return false;
 
-				bot.QueueOrder(Order.StartProduction(queue.Actor, item.Name, 1));
+				bot.QueueOrder(Order.StartProductionAI(queue.Actor, item.Name, 1));
 				productOnce = true;
 			}
 			else if (currentBuilding != null && currentBuilding.Done)

--- a/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
@@ -50,7 +50,10 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class UnitBuilderBotModule : ConditionalTrait<UnitBuilderBotModuleInfo>, IBotTick, IBotNotifyIdleBaseUnits, IBotRequestUnitProduction, IGameSaveTraitData
 	{
-		public const int FeedbackTime = 30; // ticks; = a bit over 1s. must be >= netlag.
+		/// <summary>
+		/// Feedback time in ticks.
+		/// </summary>
+		public const int FeedbackTime = 30;
 
 		readonly World world;
 		readonly Player player;
@@ -174,7 +177,7 @@ namespace OpenRA.Mods.Common.Traits
 				world.Actors.Count(a => a.Owner == player && a.Info.Name == name) >= limit)
 				return;
 
-			bot.QueueOrder(Order.StartProduction(queue.Actor, name, 1));
+			bot.QueueOrder(Order.StartProductionAI(queue.Actor, name, 1));
 		}
 
 		// In cases where we want to build a specific unit but don't know the queue name (because there's more than one possibility)
@@ -198,7 +201,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (queue != null)
 			{
-				bot.QueueOrder(Order.StartProduction(queue.Actor, name, 1));
+				bot.QueueOrder(Order.StartProductionAI(queue.Actor, name, 1));
 				AIUtils.BotDebug("{0} decided to build {1} (external request)", queue.Actor.Owner, name);
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -438,90 +438,99 @@ namespace OpenRA.Mods.Common.Traits
 			return true;
 		}
 
+		void StartProduction(Actor self, Order order)
+		{
+			var rules = self.World.Map.Rules;
+			var unit = rules.Actors[order.TargetString];
+			var bi = unit.TraitInfo<BuildableInfo>();
+
+			// Not built by this queue
+			if (!bi.Queue.Contains(Info.Type))
+				return;
+
+			// You can't build that
+			if (BuildableItems().All(b => b.Name != order.TargetString))
+				return;
+
+			// Check if the player is trying to build more units that they are allowed
+			var fromLimit = int.MaxValue;
+			if (!developerMode.AllTech)
+			{
+				if (Info.QueueLimit > 0)
+					fromLimit = Info.QueueLimit - Queue.Count;
+
+				if (Info.ItemLimit > 0)
+					fromLimit = Math.Min(fromLimit, Info.ItemLimit - Queue.Count(i => i.Item == order.TargetString));
+
+				if (bi.BuildLimit > 0)
+				{
+					var inQueue = Queue.Count(pi => pi.Item == order.TargetString);
+					var owned = self.Owner.World.ActorsHavingTrait<Buildable>().Count(a => a.Info.Name == order.TargetString && a.Owner == self.Owner);
+					fromLimit = Math.Min(fromLimit, bi.BuildLimit - (inQueue + owned));
+				}
+
+				if (fromLimit <= 0)
+					return;
+			}
+
+			var cost = GetProductionCost(unit);
+			var time = GetBuildTime(unit, bi);
+			var amountToBuild = Math.Min(fromLimit, order.ExtraData);
+			for (var n = 0; n < amountToBuild; n++)
+			{
+				if (Info.InstantCashDrain && !playerResources.TakeCash(cost, true))
+					return;
+
+				var hasPlayedSound = false;
+				BeginProduction(new ProductionItem(this, order.TargetString, cost, playerPower, () => self.World.AddFrameEndTask(_ =>
+				{
+					// Make sure the item hasn't been invalidated between the ProductionItem ticking and this FrameEndTask running
+					if (!Queue.Any(i => i.Done && i.Item == unit.Name))
+						return;
+
+					var isBuilding = unit.HasTraitInfo<BuildingInfo>();
+					var readyAudio = bi.ReadyAudio ?? Info.ReadyAudio;
+					var readyTextNotification = bi.ReadyTextNotification ?? Info.ReadyTextNotification;
+					if (isBuilding && !hasPlayedSound)
+					{
+						hasPlayedSound = Game.Sound.PlayNotification(rules, self.Owner, "Speech", readyAudio, self.Owner.Faction.InternalName);
+						TextNotificationsManager.AddTransientLine(readyTextNotification, self.Owner);
+					}
+					else if (!isBuilding)
+					{
+						if (BuildUnit(unit))
+						{
+							Game.Sound.PlayNotification(rules, self.Owner, "Speech", readyAudio, self.Owner.Faction.InternalName);
+							TextNotificationsManager.AddTransientLine(readyTextNotification, self.Owner);
+						}
+						else if (!hasPlayedSound && time > 0)
+						{
+							hasPlayedSound = Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.BlockedAudio, self.Owner.Faction.InternalName);
+							TextNotificationsManager.AddTransientLine(Info.BlockedTextNotification, self.Owner);
+						}
+					}
+				})), !order.Queued);
+			}
+		}
+
 		public void ResolveOrder(Actor self, Order order)
 		{
 			if (!Enabled)
 				return;
 
-			var rules = self.World.Map.Rules;
 			switch (order.OrderString)
 			{
 				case "StartProduction":
-					var unit = rules.Actors[order.TargetString];
-					var bi = unit.TraitInfo<BuildableInfo>();
-
-					// Not built by this queue
-					if (!bi.Queue.Contains(Info.Type))
-						return;
-
-					// You can't build that
-					if (BuildableItems().All(b => b.Name != order.TargetString))
-						return;
-
-					// Check if the player is trying to build more units that they are allowed
-					var fromLimit = int.MaxValue;
-					if (!developerMode.AllTech)
-					{
-						if (Info.QueueLimit > 0)
-							fromLimit = Info.QueueLimit - Queue.Count;
-
-						if (Info.ItemLimit > 0)
-							fromLimit = Math.Min(fromLimit, Info.ItemLimit - Queue.Count(i => i.Item == order.TargetString));
-
-						if (bi.BuildLimit > 0)
-						{
-							var inQueue = Queue.Count(pi => pi.Item == order.TargetString);
-							var owned = self.Owner.World.ActorsHavingTrait<Buildable>().Count(a => a.Info.Name == order.TargetString && a.Owner == self.Owner);
-							fromLimit = Math.Min(fromLimit, bi.BuildLimit - (inQueue + owned));
-						}
-
-						if (fromLimit <= 0)
-							return;
-					}
-
-					var cost = GetProductionCost(unit);
-					var time = GetBuildTime(unit, bi);
-					var amountToBuild = Math.Min(fromLimit, order.ExtraData);
-					for (var n = 0; n < amountToBuild; n++)
-					{
-						if (Info.InstantCashDrain && !playerResources.TakeCash(cost, true))
-							return;
-
-						var hasPlayedSound = false;
-						BeginProduction(new ProductionItem(this, order.TargetString, cost, playerPower, () => self.World.AddFrameEndTask(_ =>
-						{
-							// Make sure the item hasn't been invalidated between the ProductionItem ticking and this FrameEndTask running
-							if (!Queue.Any(i => i.Done && i.Item == unit.Name))
-								return;
-
-							var isBuilding = unit.HasTraitInfo<BuildingInfo>();
-							var readyAudio = bi.ReadyAudio ?? Info.ReadyAudio;
-							var readyTextNotification = bi.ReadyTextNotification ?? Info.ReadyTextNotification;
-							if (isBuilding && !hasPlayedSound)
-							{
-								hasPlayedSound = Game.Sound.PlayNotification(rules, self.Owner, "Speech", readyAudio, self.Owner.Faction.InternalName);
-								TextNotificationsManager.AddTransientLine(readyTextNotification, self.Owner);
-							}
-							else if (!isBuilding)
-							{
-								if (BuildUnit(unit))
-								{
-									Game.Sound.PlayNotification(rules, self.Owner, "Speech", readyAudio, self.Owner.Faction.InternalName);
-									TextNotificationsManager.AddTransientLine(readyTextNotification, self.Owner);
-								}
-								else if (!hasPlayedSound && time > 0)
-								{
-									hasPlayedSound = Game.Sound.PlayNotification(rules, self.Owner, "Speech", Info.BlockedAudio, self.Owner.Faction.InternalName);
-									TextNotificationsManager.AddTransientLine(Info.BlockedTextNotification, self.Owner);
-								}
-							}
-						})), !order.Queued);
-					}
-
+					StartProduction(self, order);
+					break;
+				case "StartProductionAI":
+					// Hack: AI production modules won't produce on queue that is producing
+					// to avoid duplicated production due to order latency or network lags.
+					if (!AllQueued().Any())
+						StartProduction(self, order);
 					break;
 				case "PauseProduction":
 					PauseProduction(order.TargetString, order.ExtraData != 0);
-
 					break;
 				case "CancelProduction":
 					CancelProduction(order.TargetString, order.ExtraData);


### PR DESCRIPTION
Currently RV, SP and maybe later GenAlpha has a large orderlatency and it makes AI duplicated production, while we can only set StructureProductionActiveDelay for one kind of game speed setting, which is unacceptable and also messed up single player game (also an important part because we need AI support for mission).

This PR can fix this problem on all game speed setting.