### PR TITLE
Allow disable Repulse in Aircraft from outside

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -297,6 +297,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly int creationActivityDelay;
 
 		bool notify = true;
+		bool repulseEnabled = true;
 
 		public static WPos GroundPosition(Actor self)
 		{
@@ -460,8 +461,12 @@ namespace OpenRA.Mods.Common.Traits
 					Pitch = Util.TickFacing(Pitch, WAngle.Zero, Info.PitchSpeed);
 			}
 
-			Repulse();
+			if (repulseEnabled)
+				Repulse();
 		}
+
+		public void EnableRepulse() { repulseEnabled = true; }
+		public void DisableRepulse() { repulseEnabled = false; }
 
 		public void Repulse()
 		{


### PR DESCRIPTION
We can use this to make aircraft automatic activity like collect supply goes smoothly.