### PR TITLE
Fix deploy crash, Mono crash on AI

### DIFF
--- a/OpenRA.Mods.AS/Scripting/Properties/GrantConditionOnDeployProperties.cs
+++ b/OpenRA.Mods.AS/Scripting/Properties/GrantConditionOnDeployProperties.cs
@@ -16,26 +16,28 @@ using OpenRA.Scripting;
 namespace OpenRA.Mods.AS.Scripting
 {
 	[ScriptPropertyGroup("General")]
-	public class DeployConditionProperties : ScriptActorProperties
+	public class GrantConditionOnDeployProperties : ScriptActorProperties
 	{
 		readonly GrantConditionOnDeploy[] gcods;
 
-		public DeployConditionProperties(ScriptContext context, Actor self)
+		public GrantConditionOnDeployProperties(ScriptContext context, Actor self)
 			: base(context, self)
 		{
 			gcods = self.TraitsImplementing<GrantConditionOnDeploy>().ToArray();
 		}
 
+		[ScriptActorPropertyActivity]
 		[Desc("Deploy the actor.")]
-		public void Deploy()
+		public void SwitchToDeploy()
 		{
 			foreach (var gcod in gcods)
 				if (!gcod.IsTraitDisabled && !gcod.IsTraitPaused)
 					gcod.Deploy();
 		}
 
+		[ScriptActorPropertyActivity]
 		[Desc("Undeploy the actor.")]
-		public void Undeploy()
+		public void SwitchToUndeploy()
 		{
 			foreach (var gcod in gcods)
 				if (!gcod.IsTraitDisabled && !gcod.IsTraitPaused)

--- a/OpenRA.Mods.AS/Traits/FreePassenger.cs
+++ b/OpenRA.Mods.AS/Traits/FreePassenger.cs
@@ -53,6 +53,9 @@ namespace OpenRA.Mods.AS.Traits
 
 			self.World.AddFrameEndTask(w =>
 			{
+				if (self.IsDead)
+					return;
+
 				foreach (var actor in Info.Actors)
 				{
 					var passenger = self.World.Map.Rules.Actors[actor].TraitInfoOrDefault<PassengerInfo>();


### PR DESCRIPTION
The best way to fix the problem is to persuade upstream change `Deploy()` in `TransformProperties` to `Transform()`. I will also give that a try.