### PR TITLE
Add GivesExperienceToMasterOrTransport and HasParent

### DIFF
--- a/OpenRA.Mods.AS/Traits/AirstrikeMaster.cs
+++ b/OpenRA.Mods.AS/Traits/AirstrikeMaster.cs
@@ -126,7 +126,8 @@ namespace OpenRA.Mods.AS.Traits
 		// invokes Attacking()
 		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
-			if (IsTraitDisabled || IsTraitPaused || !Info.ArmamentNames.Contains(a.Info.Name))
+			// HACK: If Armament hits instantly and kills the target, the target will become invalid
+			if (target.Type == TargetType.Invalid || IsTraitDisabled || IsTraitPaused || (Info.ArmamentNames.Count > 0 && !Info.ArmamentNames.Contains(a.Info.Name)))
 				return;
 
 			// Issue retarget order for already launched ones

--- a/OpenRA.Mods.AS/Traits/BaseSpawnerMaster.cs
+++ b/OpenRA.Mods.AS/Traits/BaseSpawnerMaster.cs
@@ -42,8 +42,8 @@ namespace OpenRA.Mods.AS.Traits
 		[Desc("Spawn these units. Define this like paradrop support power.")]
 		public readonly string[] Actors = Array.Empty<string>();
 
-		[Desc("Should this actor link to the actor who create them?")]
-		public readonly bool LinkToParent = false;
+		[Desc("Should this actor link to the actor who create them? This will pass master as the Parent Actor to slaves.")]
+		public readonly bool LinkToParent = true;
 
 		[Desc("Place slave will be created.")]
 		public readonly WVec[] SpawnOffset = Array.Empty<WVec>();
@@ -51,8 +51,8 @@ namespace OpenRA.Mods.AS.Traits
 		[Desc("Slave actors to contain upon creation. Set to -1 to start with full slaves.")]
 		public readonly int InitialActorCount = -1;
 
-		[Desc("Name of the armaments that grant this condition.")]
-		public readonly HashSet<string> ArmamentNames = new() { "primary" };
+		[Desc("Name of the armaments that control the slaves to attack.")]
+		public readonly HashSet<string> ArmamentNames = new();
 
 		[Desc("What happens to the slaves when the master is killed?")]
 		public readonly SpawnerSlaveDisposal SlaveDisposalOnKill = SpawnerSlaveDisposal.KillSlaves;

--- a/OpenRA.Mods.AS/Traits/BaseSpawnerMaster.cs
+++ b/OpenRA.Mods.AS/Traits/BaseSpawnerMaster.cs
@@ -42,6 +42,9 @@ namespace OpenRA.Mods.AS.Traits
 		[Desc("Spawn these units. Define this like paradrop support power.")]
 		public readonly string[] Actors = Array.Empty<string>();
 
+		[Desc("Should this actor link to the actor who create them?")]
+		public readonly bool LinkToParent = false;
+
 		[Desc("Place slave will be created.")]
 		public readonly WVec[] SpawnOffset = Array.Empty<WVec>();
 
@@ -167,9 +170,13 @@ namespace OpenRA.Mods.AS.Traits
 			if (entry.IsValid)
 				throw new InvalidOperationException("Replenish must not be run on a valid entry!");
 
+			var td = new TypeDictionary { new OwnerInit(self.Owner) };
+
+			if (Info.LinkToParent)
+				td.Add(new ParentActorInit(self));
+
 			// Some members are missing. Create a new one.
-			var slave = self.World.CreateActor(false, entry.ActorName,
-				new TypeDictionary { new OwnerInit(self.Owner) });
+			var slave = self.World.CreateActor(false, entry.ActorName, td);
 
 			// Initialize slave entry
 			InitializeSlaveEntry(slave, entry);

--- a/OpenRA.Mods.AS/Traits/CarrierMaster.cs
+++ b/OpenRA.Mods.AS/Traits/CarrierMaster.cs
@@ -118,7 +118,8 @@ namespace OpenRA.Mods.AS.Traits
 		// invokes Attacking()
 		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
-			if (IsTraitDisabled || IsTraitPaused || !Info.ArmamentNames.Contains(a.Info.Name))
+			// HACK: If Armament hits instantly and kills the target, the target will become invalid
+			if (target.Type == TargetType.Invalid || IsTraitDisabled || IsTraitPaused || (Info.ArmamentNames.Count > 0 && !Info.ArmamentNames.Contains(a.Info.Name)))
 				return;
 
 			// Issue retarget order for already launched ones

--- a/OpenRA.Mods.AS/Traits/DroneSpawnerMaster.cs
+++ b/OpenRA.Mods.AS/Traits/DroneSpawnerMaster.cs
@@ -33,9 +33,6 @@ namespace OpenRA.Mods.AS.Traits
 		[Desc("Spawn initial load all at once?")]
 		public readonly bool ShouldSpawnInitialLoad = true;
 
-		[Desc("Armament using for target check. null to use all armament.")]
-		public readonly string Armament = null;
-
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
 			base.RulesetLoaded(rules, ai);
@@ -138,10 +135,9 @@ namespace OpenRA.Mods.AS.Traits
 
 		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
-			if (Info.SlavesHaveFreeWill || target.Type == TargetType.Invalid)
-				return;
-
-			if (Info.Armament != null && a.Info.Name != Info.Armament)
+			// Drone Master only pause attack when trait is Disabled
+			// HACK: If Armament hits instantly and kills the target, the target will become invalid
+			if (target.Type == TargetType.Invalid || (Info.ArmamentNames.Count > 0 && !Info.ArmamentNames.Contains(a.Info.Name)) || Info.SlavesHaveFreeWill || IsTraitDisabled)
 				return;
 
 			AssignTargetsToSlaves(self, target);

--- a/OpenRA.Mods.AS/Traits/DroneSpawnerMaster.cs
+++ b/OpenRA.Mods.AS/Traits/DroneSpawnerMaster.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.AS.Traits
 {
-	[Desc("This actor can spawn actors.")]
+	[Desc("This actor can spawn actors. Disable this trait to disable drone control, Pause this trait to stop drone spawning")]
 	public class DroneSpawnerMasterInfo : BaseSpawnerMasterInfo
 	{
 		[Desc("Can the slaves be controlled independently?")]
@@ -146,6 +146,9 @@ namespace OpenRA.Mods.AS.Traits
 
 		void ITick.Tick(Actor self)
 		{
+			if (!self.IsInWorld)
+				return;
+
 			if (!hasSpawnInitialLoad)
 			{
 				// Spawn initial load.
@@ -160,7 +163,7 @@ namespace OpenRA.Mods.AS.Traits
 				hasSpawnInitialLoad = true;
 			}
 
-			// Time to respawn someting.
+			// Time to respawn something.
 			if (!IsTraitPaused)
 			{
 				if (spawnReplaceTicks < 0)

--- a/OpenRA.Mods.AS/Traits/GivesExperienceToMasterOrTransport.cs
+++ b/OpenRA.Mods.AS/Traits/GivesExperienceToMasterOrTransport.cs
@@ -1,0 +1,112 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.AS.Traits
+{
+	[Desc("This actor gives experience to a GainsExperience actor when they are killed.")]
+	class GivesExperienceToMasterOrTransportInfo : TraitInfo
+	{
+		[Desc("If -1, use the value of the unit cost.")]
+		public readonly int Experience = -1;
+
+		[Desc("Player relationships the attacking player needs to receive the experience.")]
+		public readonly PlayerRelationship ValidRelationships = PlayerRelationship.Neutral | PlayerRelationship.Enemy;
+
+		[Desc("Percentage of the `Experience` value that is being granted to the killing actor's mindcontrol master.")]
+		public readonly int ActorExperienceModifierOnMindControlMaster = 5000;
+
+		[Desc("Percentage of the `Experience` value that is being granted to the killing actor's parent.")]
+		public readonly int ActorExperienceModifierOnSummonMaster = 10000;
+
+		[Desc("Percentage of the `Experience` value that is being granted to the killing actor's transport.")]
+		public readonly int ActorExperienceModifierOnTransport = 5000;
+
+		public override object Create(ActorInitializer init) { return new GivesExperienceToMasterOrTransport(this); }
+	}
+
+	class GivesExperienceToMasterOrTransport : INotifyKilled, INotifyCreated
+	{
+		readonly GivesExperienceToMasterOrTransportInfo info;
+
+		int exp;
+		IEnumerable<int> experienceModifiers;
+
+		public GivesExperienceToMasterOrTransport(GivesExperienceToMasterOrTransportInfo info)
+		{
+			this.info = info;
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			var valued = self.Info.TraitInfoOrDefault<ValuedInfo>();
+			exp = info.Experience >= 0 ? info.Experience
+				: valued != null ? valued.Cost : 0;
+
+			experienceModifiers = self.TraitsImplementing<IGivesExperienceModifier>().ToArray().Select(m => m.GetGivesExperienceModifier());
+		}
+
+		void INotifyKilled.Killed(Actor self, AttackInfo e)
+		{
+			if (exp == 0 || e.Attacker == null || e.Attacker.Disposed)
+				return;
+
+			exp = Util.ApplyPercentageModifiers(exp, experienceModifiers);
+
+			var killer = e.Attacker;
+			if (killer != null)
+			{
+				if (info.ActorExperienceModifierOnMindControlMaster > 0)
+				{
+					foreach (var mindControllable in killer.TraitsImplementing<MindControllable>())
+						if (mindControllable.Master != null)
+							GiveExperience(self, mindControllable.Master, exp, info.ActorExperienceModifierOnMindControlMaster);
+				}
+
+				if (info.ActorExperienceModifierOnTransport > 0)
+				{
+					foreach (var pass in killer.TraitsImplementing<Passenger>())
+						if (pass.Transport != null)
+							GiveExperience(self, pass.Transport, exp, info.ActorExperienceModifierOnTransport);
+				}
+
+				if (info.ActorExperienceModifierOnSummonMaster > 0)
+				{
+					var parent = killer.TraitOrDefault<HasParent>()?.Parent;
+					if (parent != null)
+						GiveExperience(self, parent, exp, info.ActorExperienceModifierOnSummonMaster);
+				}
+			}
+		}
+
+		void GiveExperience(Actor self, Actor killer, int exp, int baseModifier)
+		{
+			if (killer.IsDead)
+				return;
+
+			if (!info.ValidRelationships.HasRelationship(killer.Owner.RelationshipWith(self.Owner)))
+				return;
+
+			var gainsExperience = killer.TraitOrDefault<GainsExperience>();
+			if (gainsExperience == null)
+				return;
+
+			var experienceModifier = killer.TraitsImplementing<IGainsExperienceModifier>()
+				.Select(x => x.GetGainsExperienceModifier()).Append(baseModifier);
+			gainsExperience.GiveExperience(Util.ApplyPercentageModifiers(exp, experienceModifier));
+		}
+	}
+}

--- a/OpenRA.Mods.AS/Traits/HasParent.cs
+++ b/OpenRA.Mods.AS/Traits/HasParent.cs
@@ -1,0 +1,39 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.AS.Traits
+{
+	[Desc("Hack: store the parent actor that spawn this actor.")]
+	public sealed class HasParentInfo : TraitInfo
+	{
+		public override object Create(ActorInitializer init) { return new HasParent(init); }
+	}
+
+	public sealed class HasParent : ITransformActorInitModifier
+	{
+		public Actor Parent { get; private set; }
+		public HasParent(ActorInitializer init)
+		{
+			var pa = init.GetOrDefault<ParentActorInit>()?.Value;
+			if (pa != null)
+				init.World.AddFrameEndTask(_ => Parent = pa.Actor(init.World).Value);
+		}
+
+		void ITransformActorInitModifier.ModifyTransformActorInit(Actor self, TypeDictionary init)
+		{
+			init.Add(new ParentActorInit(Parent));
+		}
+	}
+}

--- a/OpenRA.Mods.AS/Traits/MindControllable.cs
+++ b/OpenRA.Mods.AS/Traits/MindControllable.cs
@@ -48,6 +48,9 @@ namespace OpenRA.Mods.AS.Traits
 
 		public Actor Master { get; private set; }
 
+		// HACK: used for pass EXP to master or other thing when actor use Explodes attack.
+		public Actor MasterWhenDie { get; private set; }
+
 		public MindControllable(MindControllableInfo info)
 			: base(info)
 		{
@@ -122,6 +125,7 @@ namespace OpenRA.Mods.AS.Traits
 
 		void INotifyKilled.Killed(Actor self, AttackInfo e)
 		{
+			MasterWhenDie = Master;
 			UnlinkMaster(self, Master);
 		}
 

--- a/OpenRA.Mods.AS/Traits/MissileSpawnerMaster.cs
+++ b/OpenRA.Mods.AS/Traits/MissileSpawnerMaster.cs
@@ -86,10 +86,8 @@ namespace OpenRA.Mods.AS.Traits
 		// invokes Attacking()
 		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
-			if (IsTraitDisabled || IsTraitPaused)
-				return;
-
-			if (!Info.ArmamentNames.Contains(a.Info.Name))
+			// HACK: If Armament hits instantly and kills the target, the target will become invalid
+			if (target.Type == TargetType.Invalid || IsTraitDisabled || IsTraitPaused || (Info.ArmamentNames.Count > 0 && !Info.ArmamentNames.Contains(a.Info.Name)))
 				return;
 
 			// Issue retarget order for already launched ones

--- a/OpenRA.Mods.AS/Traits/MobSpawnerMaster.cs
+++ b/OpenRA.Mods.AS/Traits/MobSpawnerMaster.cs
@@ -160,7 +160,9 @@ namespace OpenRA.Mods.AS.Traits
 
 		void INotifyAttack.Attacking(Actor self, in Target target, Armament a, Barrel barrel)
 		{
-			if (Info.SlavesHaveFreeWill)
+			// Mob Master only pause attack when trait is Disabled
+			// HACK: If Armament hits instantly and kills the target, the target will become invalid
+			if (target.Type == TargetType.Invalid || (Info.ArmamentNames.Count > 0 && !Info.ArmamentNames.Contains(a.Info.Name)) || Info.SlavesHaveFreeWill || IsTraitDisabled)
 				return;
 
 			AssignTargetsToSlaves(target);

--- a/OpenRA.Mods.AS/Traits/PeriodicExplosion.cs
+++ b/OpenRA.Mods.AS/Traits/PeriodicExplosion.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.AS.Traits
 
 			delayedActions.RemoveAll(a => a.Delay <= 0);
 
-			if (IsTraitDisabled)
+			if (!self.IsInWorld || IsTraitDisabled)
 				return;
 
 			if (--fireDelay < 0)

--- a/OpenRA.Mods.AS/Traits/SmokeParticleEmitter.cs
+++ b/OpenRA.Mods.AS/Traits/SmokeParticleEmitter.cs
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.AS.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			if (IsTraitDisabled)
+			if (!self.IsInWorld || IsTraitDisabled)
 				return;
 
 			if (--ticks < 0)

--- a/OpenRA.Mods.AS/Warheads/SpawnActorWarhead.cs
+++ b/OpenRA.Mods.AS/Warheads/SpawnActorWarhead.cs
@@ -31,6 +31,9 @@ namespace OpenRA.Mods.AS.Warheads
 		[Desc("Actors to spawn.")]
 		public readonly string[] Actors = Array.Empty<string>();
 
+		[Desc("Should this actor link to the actor who create them?")]
+		public readonly bool LinkToParent = false;
+
 		[Desc("Try to parachute the actors. When unset, actors will just fall down visually using FallRate."
 			+ " Requires the Parachutable trait on all actors if set.")]
 		public readonly bool Paradrop = false;
@@ -100,6 +103,9 @@ namespace OpenRA.Mods.AS.Warheads
 					td.Add(new OwnerInit(firedBy.Owner));
 				else
 					td.Add(new OwnerInit(firedBy.World.Players.First(p => p.InternalName == InternalOwner)));
+
+				if (LinkToParent)
+					td.Add(new ParentActorInit(firedBy));
 
 				// HACK HACK HACK
 				// Immobile does not offer a check directly if the actor can exist in a position.

--- a/OpenRA.Mods.AS/Warheads/SpawnActorWarhead.cs
+++ b/OpenRA.Mods.AS/Warheads/SpawnActorWarhead.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.AS.Warheads
 		[Desc("Actors to spawn.")]
 		public readonly string[] Actors = Array.Empty<string>();
 
-		[Desc("Should this actor link to the actor who create them?")]
+		[Desc("Should this actor link to the actor who create them? This will pass firer as the Parent Actor to spawned.")]
 		public readonly bool LinkToParent = false;
 
 		[Desc("Try to parachute the actors. When unset, actors will just fall down visually using FallRate."

--- a/OpenRA.Mods.AS/Warheads/SpawnBuildingWarhead.cs
+++ b/OpenRA.Mods.AS/Warheads/SpawnBuildingWarhead.cs
@@ -28,6 +28,9 @@ namespace OpenRA.Mods.AS.Warheads
 		[Desc("Actors to spawn.")]
 		public readonly string[] Buildings = Array.Empty<string>();
 
+		[Desc("Should this building link to the actor who create them?")]
+		public readonly bool LinkToParent = false;
+
 		public readonly bool SkipMakeAnims = false;
 
 		[Desc("Owner of the spawned actor. Allowed keywords:" +
@@ -91,6 +94,9 @@ namespace OpenRA.Mods.AS.Warheads
 					td.Add(new OwnerInit(firedBy.Owner));
 				else
 					td.Add(new OwnerInit(firedBy.World.Players.First(p => p.InternalName == InternalOwner)));
+
+				if (LinkToParent)
+					td.Add(new ParentActorInit(firedBy));
 
 				while (cell.MoveNext())
 				{

--- a/OpenRA.Mods.Common/Activities/LayMines.cs
+++ b/OpenRA.Mods.Common/Activities/LayMines.cs
@@ -213,6 +213,7 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					new LocationInit(self.Location),
 					new OwnerInit(self.Owner),
+					new ParentActorInit(self)
 				});
 
 				foreach (var t in self.TraitsImplementing<INotifyMineLaying>())

--- a/OpenRA.Mods.Common/Traits/Render/FloatingSpriteEmitter.cs
+++ b/OpenRA.Mods.Common/Traits/Render/FloatingSpriteEmitter.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			if (IsTraitDisabled)
+			if (!self.IsInWorld || IsTraitDisabled)
 				return;
 
 			if (Info.Duration > 0 && --duration < 0)

--- a/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
+++ b/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new LeavesTrails(this); }
 	}
 
-	public class LeavesTrails : ConditionalTrait<LeavesTrailsInfo>, ITick
+	public class LeavesTrails : ConditionalTrait<LeavesTrailsInfo>, ITick, INotifyAddedToWorld
 	{
 		BodyOrientation body;
 		IFacing facing;
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		void ITick.Tick(Actor self)
 		{
-			if (IsTraitDisabled)
+			if (!self.IsInWorld || IsTraitDisabled)
 				return;
 
 			wasStationary = !isMoving;
@@ -153,6 +153,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 
 		protected override void TraitEnabled(Actor self)
+		{
+			cachedPosition = self.CenterPosition;
+		}
+
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
 			cachedPosition = self.CenterPosition;
 		}


### PR DESCRIPTION
This PR forcus on brings the experience passing chain features from classic Cnc and  mod extension Ares/HAres to rv-engine.

1. Transport can get experience from direct kill of the garrisoned passenger. (RA2-YR)
2. Mindcontrol master can get experience from direct kill of slaves (Ra2-Ares)
3. Spawner master can get experience from direct kill of slaves (Ra2-Ares and General angry mob).
4. Minelayer can get experience from direct kill of mines. 
5. Actor can get experience from direct kill of actor spawned by its SpawnActorsWarhead. 
