### PR TITLE
Berserkable fix and New cloak effect

### DIFF
--- a/OpenRA.Mods.AS/Traits/Berserkable.cs
+++ b/OpenRA.Mods.AS/Traits/Berserkable.cs
@@ -8,11 +8,11 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.AS.Traits
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.AS.Traits
 	public class BerserkableInfo : ConditionalTraitInfo
 	{
 		[Desc("Do not attack this type of actors when berserked.")]
-		public readonly string[] ActorsToIgnore = Array.Empty<string>();
+		public readonly BitSet<TargetableType> TargetTypesToIgnore;
 
 		public override object Create(ActorInitializer init) { return new Berserkable(this); }
 	}
@@ -108,7 +108,7 @@ namespace OpenRA.Mods.AS.Traits
 			var range = GetScanRange(atbs);
 
 			var targets = self.World.FindActorsInCircle(self.CenterPosition, range)
-				.Where(a => a != self && a.IsTargetableBy(self) && !Info.ActorsToIgnore.Contains(a.Info.Name)).ToArray();
+				.Where(a => a != self && a.IsTargetableBy(self) && !Info.TargetTypesToIgnore.Overlaps(a.GetEnabledTargetTypes())).ToArray();
 
 			var preferredtargets = targets.Where(a => a.Owner.IsAlliedWith(self.Owner));
 

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -76,8 +76,14 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Render effect to use when cloaked.")]
 		public readonly CloakStyle CloakStyle = CloakStyle.Alpha;
 
-		[Desc("The alpha level to use when cloaked when using Alpha CloakStyle.")]
-		public readonly float CloakedAlpha = 0.55f;
+		[Desc("The minimum alpha level to use when cloaked when using Alpha CloakStyle.")]
+		public readonly float MinCloakedAlpha = 0.55f;
+
+		[Desc("The maximum alpha level to use when cloaked when using Alpha CloakStyle.")]
+		public readonly float MaxCloakedAlpha = 0.55f;
+
+		[Desc("Time to to change from maximum alpha level to minimum alpha level when using Alpha CloakStyle.")]
+		public readonly int CloakAlphaChangeInterval = 10;
 
 		[Desc("The color to use when cloaked when using Color CloakStyle.")]
 		public readonly Color CloakedColor = Color.FromArgb(140, 0, 0, 0);
@@ -134,6 +140,8 @@ namespace OpenRA.Mods.Common.Traits
 		bool wasCloaked = false;
 		bool firstTick = true;
 		int cloakedToken = Actor.InvalidConditionToken;
+		float currentAlpha;
+		float alphaChange;
 
 		public Cloak(CloakInfo info)
 			: base(info)
@@ -141,6 +149,7 @@ namespace OpenRA.Mods.Common.Traits
 			remainingTime = info.InitialDelay;
 			cloakedColor = new float3(info.CloakedColor.R, info.CloakedColor.G, info.CloakedColor.B) / 255f;
 			cloakedColorAlpha = info.CloakedColor.A / 255f;
+			alphaChange = (info.MaxCloakedAlpha - info.MinCloakedAlpha) / Math.Max(1, info.CloakAlphaChangeInterval);
 		}
 
 		protected override void Created(Actor self)
@@ -160,6 +169,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (cloakedToken == Actor.InvalidConditionToken)
 					cloakedToken = self.GrantCondition(Info.CloakedCondition);
 			}
+
+			currentAlpha = Info.MinCloakedAlpha + alphaChange * Game.CosmeticRandom.Next(Info.CloakAlphaChangeInterval);
 
 			base.Created(self);
 		}
@@ -196,7 +207,7 @@ namespace OpenRA.Mods.Common.Traits
 				switch (Info.CloakStyle)
 				{
 					case CloakStyle.Alpha:
-						return r.Select(a => !a.IsDecoration && a is IModifyableRenderable mr ? mr.WithAlpha(Info.CloakedAlpha) : a);
+						return r.Select(a => !a.IsDecoration && a is IModifyableRenderable mr ? mr.WithAlpha(currentAlpha) : a);
 
 					case CloakStyle.Color:
 						return r.Select(a => !a.IsDecoration && a is IModifyableRenderable mr ?
@@ -288,6 +299,21 @@ namespace OpenRA.Mods.Common.Traits
 						self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(
 							posfunc, () => WAngle.Zero, w, Info.EffectImage, Info.UncloakEffectSequence, palette)));
 					}
+				}
+			}
+
+			if (isCloaked)
+			{
+				currentAlpha += alphaChange;
+				if (alphaChange > 0 && currentAlpha > Info.MaxCloakedAlpha)
+				{
+					alphaChange = -alphaChange;
+					currentAlpha = Info.MaxCloakedAlpha;
+				}
+				else if (alphaChange < 0 && currentAlpha < Info.MinCloakedAlpha)
+				{
+					alphaChange = -alphaChange;
+					currentAlpha = Info.MinCloakedAlpha;
 				}
 			}
 


### PR DESCRIPTION
Berserkable: add TargetTypesToIgnore so we can ignore tree target and drone target when berserk.

Cloak: add shift effect controlled by MinCloakedAlpha, MaxCloakedAlpha and CloakAlphaChangeInterval.
![cloak effect](https://github.com/MustaphaTR/OpenRA/assets/13763394/7964aa23-6e17-40fc-bf0c-a01318733146)

