### PR TITLE
Label text converted by translation, so we can fix some warnings in utility check.

### DIFF
--- a/OpenRA.Mods.AS/Widgets/Logic/Ingame/IngameActorStatsLogic.cs
+++ b/OpenRA.Mods.AS/Widgets/Logic/Ingame/IngameActorStatsLogic.cs
@@ -339,10 +339,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						else
 							labelText = usv.GetValueFor(index);
 
-						return string.IsNullOrEmpty(labelText) ? "" : statLabel.Text + labelText;
+						return string.IsNullOrEmpty(labelText) ? "" : TranslationProvider.GetString(statLabel.Text) + labelText;
 					}
 
-					return statLabel.Text;
+					return TranslationProvider.GetString(statLabel.Text);
 				};
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return;
 
 				var cost = sp.Info.Cost;
-				var costString = costLabel.Text + cost.ToString(NumberFormatInfo.CurrentInfo);
+				var costString = TranslationProvider.GetString(costLabel.Text) + cost.ToString(NumberFormatInfo.CurrentInfo);
 				costLabel.GetText = () => costString;
 				costLabel.GetColor = () => playerResources.Cash + playerResources.Resources >= cost
 					? Color.White : Color.Red;


### PR DESCRIPTION
![image](https://github.com/MustaphaTR/OpenRA/assets/13763394/0d575ca4-7ac9-4175-9c89-d50d5cceb568)
